### PR TITLE
Update database with current course data

### DIFF
--- a/AbetApi/Controllers/SectionController.cs
+++ b/AbetApi/Controllers/SectionController.cs
@@ -57,7 +57,7 @@ namespace AbetApi.Controllers
         //                       instructorEUD string, isSectioncompleted boolean, 
         //                       sectionNumber string,numberOfStudents int
         ////////////////////////////////////////////////////////////////////////////////////
-        [Authorize(Roles = RoleTypes.Admin)]
+        [Authorize(Roles = RoleTypes.Instructor)] // Fall 2022 changed this to instructor. Front end calls
         [HttpGet("GetSection")]
         public async Task<IActionResult> GetSection(string term, int year, string department, string courseNumber, string sectionNumber)
         {

--- a/AbetApi/Data/Database.cs
+++ b/AbetApi/Data/Database.cs
@@ -43,134 +43,7 @@ namespace AbetApi.Data
 
         public void WIPDoStuff()
         {
-            /* ================= INFINITE LOOP & TEAM 27 ================= */
-
-            // create a new semester
-            _ = Semester.AddSemester(new Semester("Fall", 2022));
-
-            // add majors to semester
-            _ = Major.AddMajor("Fall", 2022, "CE");
-            _ = Major.AddMajor("Fall", 2022, "CS");
-            _ = Major.AddMajor("Fall", 2022, "IT");
-
-            // add courses to semester
-            _ = Course.AddCourse("Fall", 2022, new Course("pls0112", "1030", "Computer Science I", "", false, "CSCE"));
-            _ = Course.AddCourse("Fall", 2022, new Course("amm0813", "1030", "Computer Science I", "", false, "CSCE"));
-            //_ = Course.AddCourse("Fall", 2022, new Course("amm0813", "1030", "Computer Science I", "", false, "CSCE")); // duplicate
-            _ = Course.AddCourse("Fall", 2022, new Course("dr0702", "1030", "Computer Science I", "", false, "CSCE"));
-            _ = Course.AddCourse("Fall", 2022, new Course("bj0141", "1035", "Computer Programming I", "", false, "CSCE"));
-            _ = Course.AddCourse("Fall", 2022, new Course("dmk0080", "1040", "Computer Science II", "", false, "CSCE"));
-            //_ = Course.AddCourse("Fall", 2022, new Course("dmk0080", "1040", "Computer Science II", "", false, "CSCE")); // duplicate
-            _ = Course.AddCourse("Fall", 2022, new Course("bm0756", "1045", "Computer Programming II", "", false, "CSCE"));
-            _ = Course.AddCourse("Fall", 2022, new Course("yl0340", "2100", "Foundations of Computing", "", false, "CSCE"));
-            //_ = Course.AddCourse("Fall", 2022, new Course("yl0340", "2100", "Foundations of Computing", "", false, "CSCE")); // duplicate
-            //_ = Course.AddCourse("Fall", 2022, new Course("yl0340", "2100", "Foundations of Computing", "", false, "CSCE")); // duplicate
-            _ = Course.AddCourse("Fall", 2022, new Course("hw0109", "2100", "Foundations of Computing", "", false, "CSCE"));
-            _ = Course.AddCourse("Fall", 2022, new Course("dr0702", "2100", "Foundations of Computing", "", false, "CSCE"));
-            _ = Course.AddCourse("Fall", 2022, new Course("csc0168", "2110", "Foundations of Data Structures", "", false, "CSCE"));
-            //_ = Course.AddCourse("Fall", 2022, new Course("csc0168", "2110", "Foundations of Data Structures", "", false, "CSCE")); // duplicate
-            _ = Course.AddCourse("Fall", 2022, new Course("dr0702", "2110", "Foundations of Data Structures", "", false, "CSCE"));
-
-            // add sections to courses
-            _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("pls0112", false, "001", 120));
-            _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("pls0112", false, "002", 120));
-            _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("amm0813", false, "003", 130));
-            _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("amm0813", false, "004", 94));
-            _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("dr0702", false, "501", 25));
-
-            _ = Section.AddSection("Fall", 2022, "CSCE", "1035", new Section("bj0141", false, "001", 32));
-
-            _ = Section.AddSection("Fall", 2022, "CSCE", "1040", new Section("dmk0080", false, "001", 118));
-            _ = Section.AddSection("Fall", 2022, "CSCE", "1040", new Section("dmk0080", false, "002", 118));
-
-            _ = Section.AddSection("Fall", 2022, "CSCE", "1045", new Section("bm0756", false, "001", 32));
-
-            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("yl0340", false, "001", 75));
-            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("yl0340", false, "002", 75));
-            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("yl0340", false, "003", 68));
-            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("hw0109", false, "004", 95));
-            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("dr0702", false, "550", 40));
-
-            _ = Section.AddSection("Fall", 2022, "CSCE", "2110", new Section("csc0168", false, "001", 110));
-            _ = Section.AddSection("Fall", 2022, "CSCE", "2110", new Section("csc0168", false, "002", 110));
-            _ = Section.AddSection("Fall", 2022, "CSCE", "2110", new Section("dr0702", false, "501", 40)); // missing number of students (currently 0)
-
-            // add major outcomes
-            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CE", new MajorOutcome("1", "An ability to identify, formulate, and solve complex engineering problems by applying principles of engineering, science, and mathematics."));
-            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CE", new MajorOutcome("2", "An ability to acquire and apply new knowledge as needed, using appropriate learning strategies."));
-
-            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("1", "Analyze a complex computing problem and to apply principles of computing and other relevant disciplines to identify solutions."));
-            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("2", "Design, implement, and evaluate a computing-based solution to meet a given set of computing requirements in the context of the program’s discipline."));
-            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("3", "Apply computer science theory and software development fundamentals to produce computing-based solutions."));
-
-            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "IT", new MajorOutcome("1", "Analyze a complex computing problem and to apply principles of computing and other relevant disciplines to identify solutions."));
-            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "IT", new MajorOutcome("2", "Design, implement, and evaluate a computing-based solution to meet a given set of computing requirements in the context of the program’s discipline."));
-            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "IT", new MajorOutcome("3", "Identify and analyze user needs and to take them into account in the selection, creation, integration, evaluation, and administration of computing-based systems."));
-
-            // add course outcome to course
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1030", new CourseOutcome("1", "Describe how a computer’s CPU, Main Memory, Secondary Storage and I/O work together to execute a computer program."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1030", new CourseOutcome("2", "Make use of a computer system’s hardware, editor(s), operating system, system software and network to build computer software and submit that software for grading."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1030", new CourseOutcome("3", "Describe algorithms to perform “simple” tasks such as numeric computation, searching and sorting, choosing among several options, string manipulation, and use of pseudo-random numbers in simulation of such tasks as rolling dice."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1030", new CourseOutcome("4", "Write readable, efficient and correct C/C++ programs that include programming structures such as assignment statements, selection statements, loops, arrays, pointers, console and file I/O, structures, command line arguments, both standard library and user-defined functions, and multiple header (.h) and code (.c or .cpp) files."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1030", new CourseOutcome("5", "Use commonly accepted practices and tools to find and fix runtime and logical errors in software."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1030", new CourseOutcome("6", "Describe a software process model that can be used to develop significant applications composed of hundreds of functions."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1030", new CourseOutcome("7", "Perform the steps necessary to edit, compile, link and execute C/C++ programs."));
-
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1035", new CourseOutcome("1", "Describe how a computer’s CPU, Main Memory, Secondary Storage, and I/O work together to execute a computer program."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1035", new CourseOutcome("2", "Make use of a computer system’s hardware, editor(s), operating system, system software, and network to build computer software and submit that software for grading."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1035", new CourseOutcome("3", "Describe algorithms to perform \"simple\" tasks such as numeric computation, searching and sorting, choosing among several options, string manipulation, and use of pseudo-random numbers in simulation of tasks such as rolling dice."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1035", new CourseOutcome("4", "Write readable, efficient, and correct programs that include programming structures such as assignment and selection statements, loops, lists, console and file I/O, command line arguments, and both standard library and user-defined functions."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1035", new CourseOutcome("5", "Use commonly accepted practices and tools to find and fix syntax, runtime, and logical errors in software."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1035", new CourseOutcome("6", "Describe a software process model that can be used to develop significant applications composed of hundreds of functions."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1035", new CourseOutcome("7", "Perform the steps necessary to edit and execute programs."));
-
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("1", "Write readable, efficient, and correct C++ programs for all programming constructs defined for Programming Fundamentals I plus dynamic memory allocation, bit manipulation operators, exceptions, classes and inheritance."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("2", "Design and implement recursive algorithms in C/C++."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("3", "Use common data structures and techniques such as stacks, queues, linked lists, trees and hashing."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("4", "Create programs using the Standard Template Library."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("5", "Use a symbolic debugger to find and fix runtime and logical errors in C software."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("6", "Using a software process model, design and implement a significant software application in C++. Significant software in this context means a software application with at least five files, ten functions and a make file."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("7", "Implement, compile and run C++ programs that includes classes, inheritance, virtual functions, function overloading and overriding, as well as other aspects of Polymorphism."));
-
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1045", new CourseOutcome("1", "Write readable, efficient, and correct programs for basic programming constructs plus dynamic memory allocation, bit manipulation operators, exceptions, classes, and inheritance."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1045", new CourseOutcome("2", "Design and implement recursive algorithms using a modern programming language."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1045", new CourseOutcome("3", "Use common data structures and techniques such as stacks, queues, linked lists, trees, and hashing."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1045", new CourseOutcome("4", "Create programs using the appropriate libraries for the programming language."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1045", new CourseOutcome("5", "Use a symbolic debugger to find and fix runtime and logical errors in software."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1045", new CourseOutcome("6", "Use a software process model to design and implement a significant software application in a modern programming language consisting of multiple files and functions and a make file."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1045", new CourseOutcome("7", "Implement, compile, and run programs that include classes, inheritance, virtual functions, function overloading and overriding, as well as other aspects of polymorphism."));
-
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("1", "Define and use the basic operations of sets, functions, and relations."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("2", "Define and demonstrate the basic properties of trees and graphs."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("3", "Use elementary graph and tree algorithms including traversals and searches."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("4", "Describe assertions in propositional logic form."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("5", "Describe simple circuits, I/O, and satisfiability using Boolean logic."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("6", "Use combinatorics and conditional probability in solving real-world problems."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("7", "Demonstrate a solid foundation in conceptual and formal models by describing loop structures in summation and/or product notation."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("8", "Demonstrate an introductory knowledge of finite state machines."));
-
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("1", "Demonstrate the ability to use Integrated Development Environments (IDE) and use formal debugging tools and techniques to develop C/C++ programs. "));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("2", "Demonstrate the ability to develop unit tests and testing strategies for C/C++ programs."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("3", "Demonstrate the ability to use code repositories for project development."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("4", "Use abstraction in the design and implementation of algorithms, such as sorting and searching algorithms."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("5", "Design and implement programming solutions to problems in C or C++."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("6", "Collaborate with other students in a team towards the design and development of programming solutions."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("7", "Use regular expressions in C/C++ programs to match patterns."));
-            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("8", "Use of hash tables in design of software."));
-
-            // link major outcomes to course outcomes
-            // HELP: how do you guys want to link these? do we need to ask for more info?
-            //                                                courseOutcomeName ->|   mjr.   |<- majorOutcomeName
-            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "1", "CS", "1");
-            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "1", "CS", "2");
-            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "2", "CS", "3");
-            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "3", "CS", "3");
-
-
-            /* ====== END ====== INFINITE LOOP & TEAM 27 ====== END ====== */
-
-
-
+            /*
             _ = Semester.AddSemester(new Semester("Spring", 2022));
             _ = Course.AddCourse("Spring", 2022, new Course("cas0231", "1030", "Something", "", false, "CSCE"));
             _ = Course.AddCourse("Spring", 2022, new Course("cas0231", "1040", "Something", "", false, "CSCE"));
@@ -285,10 +158,143 @@ namespace AbetApi.Data
             _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "001", "3", "IT", 10);
             _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "002", "3", "IT", 10);
             _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "003", "3", "IT", 10);
-
+            */
             //For testing the deep copy.
             //_ = Semester.AddSemester(new Semester("Fall", 2022));
             //Semester.DeepCopy("Fall", 2022, "Spring", 2022);
+
+            //WipeTables();
+
+            /* ================= INFINITE LOOP & TEAM 27 ================= */
+
+            // create a new semester
+            _ = Semester.AddSemester(new Semester("Fall", 2022));
+
+            // add majors to semester
+            _ = Major.AddMajor("Fall", 2022, "CE");
+            _ = Major.AddMajor("Fall", 2022, "CS");
+            _ = Major.AddMajor("Fall", 2022, "IT");
+
+            // add courses to semester
+            _ = Course.AddCourse("Fall", 2022, new Course("pls0112", "1030", "Computer Science I", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("amm0813", "1030", "Computer Science I", "", false, "CSCE"));
+            //_ = Course.AddCourse("Fall", 2022, new Course("amm0813", "1030", "Computer Science I", "", false, "CSCE")); // duplicate
+            _ = Course.AddCourse("Fall", 2022, new Course("dr0702", "1030", "Computer Science I", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("bj0141", "1035", "Computer Programming I", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("dmk0080", "1040", "Computer Science II", "", false, "CSCE"));
+            //_ = Course.AddCourse("Fall", 2022, new Course("dmk0080", "1040", "Computer Science II", "", false, "CSCE")); // duplicate
+            _ = Course.AddCourse("Fall", 2022, new Course("bm0756", "1045", "Computer Programming II", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("yl0340", "2100", "Foundations of Computing", "", false, "CSCE"));
+            //_ = Course.AddCourse("Fall", 2022, new Course("yl0340", "2100", "Foundations of Computing", "", false, "CSCE")); // duplicate
+            //_ = Course.AddCourse("Fall", 2022, new Course("yl0340", "2100", "Foundations of Computing", "", false, "CSCE")); // duplicate
+            _ = Course.AddCourse("Fall", 2022, new Course("hw0109", "2100", "Foundations of Computing", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("dr0702", "2100", "Foundations of Computing", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("csc0168", "2110", "Foundations of Data Structures", "", false, "CSCE"));
+            //_ = Course.AddCourse("Fall", 2022, new Course("csc0168", "2110", "Foundations of Data Structures", "", false, "CSCE")); // duplicate
+            _ = Course.AddCourse("Fall", 2022, new Course("dr0702", "2110", "Foundations of Data Structures", "", false, "CSCE"));
+
+            // add sections to courses
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("pls0112", false, "001", 120));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("pls0112", false, "002", 120));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("amm0813", false, "003", 130));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("amm0813", false, "004", 94));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("dr0702", false, "501", 25));
+
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1035", new Section("bj0141", false, "001", 32));
+
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1040", new Section("dmk0080", false, "001", 118));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1040", new Section("dmk0080", false, "002", 118));
+
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1045", new Section("bm0756", false, "001", 32));
+
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("yl0340", false, "001", 75));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("yl0340", false, "002", 75));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("yl0340", false, "003", 68));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("hw0109", false, "004", 95));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("dr0702", false, "550", 40));
+
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2110", new Section("csc0168", false, "001", 110));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2110", new Section("csc0168", false, "002", 110));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2110", new Section("dr0702", false, "501", 40));
+
+            // add major outcomes
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CE", new MajorOutcome("1", "An ability to identify, formulate, and solve complex engineering problems by applying principles of engineering, science, and mathematics."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CE", new MajorOutcome("2", "An ability to acquire and apply new knowledge as needed, using appropriate learning strategies."));
+
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("1", "Analyze a complex computing problem and to apply principles of computing and other relevant disciplines to identify solutions."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("2", "Design, implement, and evaluate a computing-based solution to meet a given set of computing requirements in the context of the program’s discipline."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("3", "Apply computer science theory and software development fundamentals to produce computing-based solutions."));
+
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "IT", new MajorOutcome("1", "Analyze a complex computing problem and to apply principles of computing and other relevant disciplines to identify solutions."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "IT", new MajorOutcome("2", "Design, implement, and evaluate a computing-based solution to meet a given set of computing requirements in the context of the program’s discipline."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "IT", new MajorOutcome("3", "Identify and analyze user needs and to take them into account in the selection, creation, integration, evaluation, and administration of computing-based systems."));
+
+            // add course outcome to course
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1030", new CourseOutcome("1", "Describe how a computer’s CPU, Main Memory, Secondary Storage and I/O work together to execute a computer program."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1030", new CourseOutcome("2", "Make use of a computer system’s hardware, editor(s), operating system, system software and network to build computer software and submit that software for grading."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1030", new CourseOutcome("3", "Describe algorithms to perform “simple” tasks such as numeric computation, searching and sorting, choosing among several options, string manipulation, and use of pseudo-random numbers in simulation of such tasks as rolling dice."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1030", new CourseOutcome("4", "Write readable, efficient and correct C/C++ programs that include programming structures such as assignment statements, selection statements, loops, arrays, pointers, console and file I/O, structures, command line arguments, both standard library and user-defined functions, and multiple header (.h) and code (.c or .cpp) files."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1030", new CourseOutcome("5", "Use commonly accepted practices and tools to find and fix runtime and logical errors in software."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1030", new CourseOutcome("6", "Describe a software process model that can be used to develop significant applications composed of hundreds of functions."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1030", new CourseOutcome("7", "Perform the steps necessary to edit, compile, link and execute C/C++ programs."));
+
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1035", new CourseOutcome("1", "Describe how a computer’s CPU, Main Memory, Secondary Storage, and I/O work together to execute a computer program."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1035", new CourseOutcome("2", "Make use of a computer system’s hardware, editor(s), operating system, system software, and network to build computer software and submit that software for grading."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1035", new CourseOutcome("3", "Describe algorithms to perform \"simple\" tasks such as numeric computation, searching and sorting, choosing among several options, string manipulation, and use of pseudo-random numbers in simulation of tasks such as rolling dice."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1035", new CourseOutcome("4", "Write readable, efficient, and correct programs that include programming structures such as assignment and selection statements, loops, lists, console and file I/O, command line arguments, and both standard library and user-defined functions."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1035", new CourseOutcome("5", "Use commonly accepted practices and tools to find and fix syntax, runtime, and logical errors in software."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1035", new CourseOutcome("6", "Describe a software process model that can be used to develop significant applications composed of hundreds of functions."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1035", new CourseOutcome("7", "Perform the steps necessary to edit and execute programs."));
+
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("1", "Write readable, efficient, and correct C++ programs for all programming constructs defined for Programming Fundamentals I plus dynamic memory allocation, bit manipulation operators, exceptions, classes and inheritance."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("2", "Design and implement recursive algorithms in C/C++."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("3", "Use common data structures and techniques such as stacks, queues, linked lists, trees and hashing."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("4", "Create programs using the Standard Template Library."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("5", "Use a symbolic debugger to find and fix runtime and logical errors in C software."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("6", "Using a software process model, design and implement a significant software application in C++. Significant software in this context means a software application with at least five files, ten functions and a make file."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("7", "Implement, compile and run C++ programs that includes classes, inheritance, virtual functions, function overloading and overriding, as well as other aspects of Polymorphism."));
+
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1045", new CourseOutcome("1", "Write readable, efficient, and correct programs for basic programming constructs plus dynamic memory allocation, bit manipulation operators, exceptions, classes, and inheritance."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1045", new CourseOutcome("2", "Design and implement recursive algorithms using a modern programming language."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1045", new CourseOutcome("3", "Use common data structures and techniques such as stacks, queues, linked lists, trees, and hashing."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1045", new CourseOutcome("4", "Create programs using the appropriate libraries for the programming language."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1045", new CourseOutcome("5", "Use a symbolic debugger to find and fix runtime and logical errors in software."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1045", new CourseOutcome("6", "Use a software process model to design and implement a significant software application in a modern programming language consisting of multiple files and functions and a make file."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1045", new CourseOutcome("7", "Implement, compile, and run programs that include classes, inheritance, virtual functions, function overloading and overriding, as well as other aspects of polymorphism."));
+
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("1", "Define and use the basic operations of sets, functions, and relations."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("2", "Define and demonstrate the basic properties of trees and graphs."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("3", "Use elementary graph and tree algorithms including traversals and searches."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("4", "Describe assertions in propositional logic form."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("5", "Describe simple circuits, I/O, and satisfiability using Boolean logic."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("6", "Use combinatorics and conditional probability in solving real-world problems."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("7", "Demonstrate a solid foundation in conceptual and formal models by describing loop structures in summation and/or product notation."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("8", "Demonstrate an introductory knowledge of finite state machines."));
+
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("1", "Demonstrate the ability to use Integrated Development Environments (IDE) and use formal debugging tools and techniques to develop C/C++ programs. "));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("2", "Demonstrate the ability to develop unit tests and testing strategies for C/C++ programs."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("3", "Demonstrate the ability to use code repositories for project development."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("4", "Use abstraction in the design and implementation of algorithms, such as sorting and searching algorithms."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("5", "Design and implement programming solutions to problems in C or C++."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("6", "Collaborate with other students in a team towards the design and development of programming solutions."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("7", "Use regular expressions in C/C++ programs to match patterns."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("8", "Use of hash tables in design of software."));
+
+            // link major outcomes to course outcomes
+            // HELP: how do you guys want to link these? do we need to ask for more info?
+            //                                                courseOutcomeName ->|   mjr.   |<- majorOutcomeName
+            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "1", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "1", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "2", "CS", "3");
+            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "3", "CS", "3");
+
+
+            //For testing the deep copy.
+            //_ = Semester.AddSemester(new Semester("Spring", 2023));
+            //Semester.DeepCopy("Spring", 2023, "Fall", 2022);
+
+            /* ====== END ====== INFINITE LOOP & TEAM 27 ====== END ====== */
+
         }
 
         // This function is here to run arbitrary code from the database class
@@ -445,6 +451,8 @@ namespace AbetApi.Data
 
             //var eh = CourseOutcome.MapCourseOutcomeToMajorOutcome("Fall", 2022, "CSCE", "1040", "3", "CS").Result;
             System.Console.WriteLine(""); //This is a placeholder for a debugger break point
+
+
         }
     }
 }

--- a/AbetApi/Data/Database.cs
+++ b/AbetApi/Data/Database.cs
@@ -218,17 +218,28 @@ namespace AbetApi.Data
             _ = Section.AddSection("Fall", 2022, "CSCE", "2110", new Section("csc0168", false, "002", 110));
             _ = Section.AddSection("Fall", 2022, "CSCE", "2110", new Section("dr0702", false, "501", 40));
 
-            // add major outcomes
+            // add major outcomes ** STUDENT OUTCOMES ** 
             _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CE", new MajorOutcome("1", "An ability to identify, formulate, and solve complex engineering problems by applying principles of engineering, science, and mathematics."));
-            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CE", new MajorOutcome("2", "An ability to acquire and apply new knowledge as needed, using appropriate learning strategies."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CE", new MajorOutcome("2", "An ability to apply engineering design to produce solutions that meet specified needs with consideration of public health, safety,and welfare, as well as global, cultural, social, environmental, and economic factors."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CE", new MajorOutcome("3", "An ability to communicate effectively with a range of audiences."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CE", new MajorOutcome("4", "An ability to recognize ethical and professional responsibilities in engineering situations and make informed judgments, which must consider the impact of engineering solutions in global, economic, environmental, and societal contexts."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CE", new MajorOutcome("5", "An ability to function effectively on a team whose members together provide leadership, create a collaborative and inclusive environment, establish goals, plan tasks, and meet objectives."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CE", new MajorOutcome("6", "An ability to develop and conduct appropriate experimentation, analyze and interpret data, and use engineering judgment to draw conclusions."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CE", new MajorOutcome("7", "An ability to acquire and apply new knowledge as needed, using appropriate learning strategies."));
 
-            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("1", "Analyze a complex computing problem and to apply principles of computing and other relevant disciplines to identify solutions."));
-            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("2", "Design, implement, and evaluate a computing-based solution to meet a given set of computing requirements in the context of the program’s discipline."));
-            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("3", "Apply computer science theory and software development fundamentals to produce computing-based solutions."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("1", "An ability to analyze a complex computing problem and to apply principles of computing and other relevant disciplines to identify solutions."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("2", "An ability to design, implement, and evaluate a computing-based solution to meet a given set of computing requirements in the context of the program’s discipline."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("3", "An ability to communicate effectively in a variety of professional contexts."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("4", "An ability to recognize professional responsibilities and make informed judgements in computing practice based on legal and ethical principles."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("5", "An ability to function effectively as a member or leader of a team engaged in activities appropriate to the program’s discipline."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("6", "An ability to apply computer science theory and software development fundamentals to produce computing-based solutions."));
 
-            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "IT", new MajorOutcome("1", "Analyze a complex computing problem and to apply principles of computing and other relevant disciplines to identify solutions."));
-            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "IT", new MajorOutcome("2", "Design, implement, and evaluate a computing-based solution to meet a given set of computing requirements in the context of the program’s discipline."));
-            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "IT", new MajorOutcome("3", "Identify and analyze user needs and to take them into account in the selection, creation, integration, evaluation, and administration of computing-based systems."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "IT", new MajorOutcome("1", "An ability to analyze a complex computing problem and to apply principles of computing and other relevant disciplines to identify solutions."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "IT", new MajorOutcome("2", "An ability to design, implement, and evaluate a computing-based solution to meet a given set of computing requirements in the context of the program’s discipline."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "IT", new MajorOutcome("3", "An ability to communicate effectively in a variety of professional contexts."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "IT", new MajorOutcome("4", "An ability to recognize professional responsibilities and make informed judgements in computing practice based on legal and ethical principles."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "IT", new MajorOutcome("5", "An ability to function effectively as a member or leader of a team engaged in activities appropriate to the program’s discipline."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "IT", new MajorOutcome("6", "An ability to identify and analyze user needs and to take them into account in the selection, creation, integration, evaluation, and administration of computing-based systems."));
 
             // add course outcome to course
             _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1030", new CourseOutcome("1", "Describe how a computer’s CPU, Main Memory, Secondary Storage and I/O work together to execute a computer program."));
@@ -281,13 +292,86 @@ namespace AbetApi.Data
             _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("7", "Use regular expressions in C/C++ programs to match patterns."));
             _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("8", "Use of hash tables in design of software."));
 
-            // link major outcomes to course outcomes
-            // HELP: how do you guys want to link these? do we need to ask for more info?
-            //                                                courseOutcomeName ->|   mjr.   |<- majorOutcomeName
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "1", "CS", "1");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "1", "CS", "2");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "2", "CS", "3");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "3", "CS", "3");
+            // link major outcomes to course outcomes **STUDENT OUTCOME TO COURSE OUTCOME**
+            // 1030 CE
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "3", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "4", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "7", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "1", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "2", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "5", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "6", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "7", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "4", "CE", "4");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "3", "CE", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "4", "CE", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "7", "CE", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "3", "CE", "7");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "4", "CE", "7");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "7", "CE", "7");
+            // 1035 CE (same as 1030)
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "3", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "4", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "7", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "1", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "2", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "5", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "6", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "7", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "4", "CE", "4");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "3", "CE", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "4", "CE", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "7", "CE", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "3", "CE", "7");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "4", "CE", "7");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "7", "CE", "7");
+            // 1040 CE
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "1", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "2", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "3", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "4", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "5", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "6", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "7", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "2", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "6", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "7", "CE", "2");
+            // 1045 CE (same as 1040)
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "1", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "2", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "3", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "4", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "5", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "6", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "7", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "2", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "6", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "7", "CE", "2");
+            // 2100 CE
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "1", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "2", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "6", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "7", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "3", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "5", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "3", "CE", "3");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "5", "CE", "3");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "3", "CE", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "4", "CE", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "5", "CE", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "7", "CE", "7");
+            // 2110 CE
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "5", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "6", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "7", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "1", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "2", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "3", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "4", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "1", "CE", "5");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "2", "CE", "5");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "3", "CE", "5");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "4", "CE", "5");
 
             //Adds Users
             _ = User.AddUser(new User("Curtis", "Chambers", "csc0168"));

--- a/AbetApi/Data/Database.cs
+++ b/AbetApi/Data/Database.cs
@@ -289,6 +289,35 @@ namespace AbetApi.Data
             _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "2", "CS", "3");
             _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "3", "CS", "3");
 
+            //Adds Users
+            _ = User.AddUser(new User("Curtis", "Chambers", "csc0168"));
+            _ = User.AddUser(new User("Beilei", "Jiang", "bj0141"));
+            _ = User.AddUser(new User("David", "Keathly", "dmk0080"));
+            _ = User.AddUser(new User("Yuan", "Li", "yl0340"));
+            _ = User.AddUser(new User("Amar", "Majarjan", "amm0813"));
+            _ = User.AddUser(new User("Beddhu", "Murali", "bm0756"));
+            _ = User.AddUser(new User("Diana", "Rabah", "dr0702"));
+            _ = User.AddUser(new User("Pradhumna", "Shrestha", "pls0112"));
+            _ = User.AddUser(new User("Haili", "Wang", "hw0109"));
+
+            //Creates default roles
+            _ = Role.CreateRole(new Role("Admin"));
+            _ = Role.CreateRole(new Role("Coordinator"));
+            _ = Role.CreateRole(new Role("Instructor"));
+            _ = Role.CreateRole(new Role("Student"));
+
+            //Gives admin access to:
+
+            //Gives instructor access to:
+            _ = Role.AddRoleToUser("csc0168", "Instructor");
+            _ = Role.AddRoleToUser("bj0141", "Instructor");
+            _ = Role.AddRoleToUser("dmk0080", "Instructor");
+            _ = Role.AddRoleToUser("yl0340", "Instructor");
+            _ = Role.AddRoleToUser("amm0813", "Instructor");
+            _ = Role.AddRoleToUser("bm0756", "Instructor");
+            _ = Role.AddRoleToUser("dr0702", "Instructor");
+            _ = Role.AddRoleToUser("pls0112", "Instructor");
+            _ = Role.AddRoleToUser("hw0109", "Instructor");
 
             //For testing the deep copy.
             //_ = Semester.AddSemester(new Semester("Spring", 2023));

--- a/AbetApi/Data/Database.cs
+++ b/AbetApi/Data/Database.cs
@@ -177,22 +177,22 @@ namespace AbetApi.Data
             _ = Major.AddMajor("Fall", 2022, "IT");
 
             // add courses to semester
-            _ = Course.AddCourse("Fall", 2022, new Course("pls0112", "1030", "Computer Science I", "", false, "CSCE"));
-            _ = Course.AddCourse("Fall", 2022, new Course("amm0813", "1030", "Computer Science I", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("coordinator", "1030", "Computer Science I", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("coordinator", "1030", "Computer Science I", "", false, "CSCE"));
             //_ = Course.AddCourse("Fall", 2022, new Course("amm0813", "1030", "Computer Science I", "", false, "CSCE")); // duplicate
-            _ = Course.AddCourse("Fall", 2022, new Course("dr0702", "1030", "Computer Science I", "", false, "CSCE"));
-            _ = Course.AddCourse("Fall", 2022, new Course("bj0141", "1035", "Computer Programming I", "", false, "CSCE"));
-            _ = Course.AddCourse("Fall", 2022, new Course("dmk0080", "1040", "Computer Science II", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("coordinator", "1030", "Computer Science I", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("coordinator", "1035", "Computer Programming I", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("coordinator", "1040", "Computer Science II", "", false, "CSCE"));
             //_ = Course.AddCourse("Fall", 2022, new Course("dmk0080", "1040", "Computer Science II", "", false, "CSCE")); // duplicate
-            _ = Course.AddCourse("Fall", 2022, new Course("bm0756", "1045", "Computer Programming II", "", false, "CSCE"));
-            _ = Course.AddCourse("Fall", 2022, new Course("yl0340", "2100", "Foundations of Computing", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("coordinator", "1045", "Computer Programming II", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("coordinator", "2100", "Foundations of Computing", "", false, "CSCE"));
             //_ = Course.AddCourse("Fall", 2022, new Course("yl0340", "2100", "Foundations of Computing", "", false, "CSCE")); // duplicate
             //_ = Course.AddCourse("Fall", 2022, new Course("yl0340", "2100", "Foundations of Computing", "", false, "CSCE")); // duplicate
-            _ = Course.AddCourse("Fall", 2022, new Course("hw0109", "2100", "Foundations of Computing", "", false, "CSCE"));
-            _ = Course.AddCourse("Fall", 2022, new Course("dr0702", "2100", "Foundations of Computing", "", false, "CSCE"));
-            _ = Course.AddCourse("Fall", 2022, new Course("csc0168", "2110", "Foundations of Data Structures", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("coordinator", "2100", "Foundations of Computing", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("coordinator", "2100", "Foundations of Computing", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("coordinator", "2110", "Foundations of Data Structures", "", false, "CSCE"));
             //_ = Course.AddCourse("Fall", 2022, new Course("csc0168", "2110", "Foundations of Data Structures", "", false, "CSCE")); // duplicate
-            _ = Course.AddCourse("Fall", 2022, new Course("dr0702", "2110", "Foundations of Data Structures", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("coordinator", "2110", "Foundations of Data Structures", "", false, "CSCE"));
 
             // add sections to courses
             _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("pls0112", false, "001", 120));
@@ -300,6 +300,9 @@ namespace AbetApi.Data
             _ = User.AddUser(new User("Pradhumna", "Shrestha", "pls0112"));
             _ = User.AddUser(new User("Haili", "Wang", "hw0109"));
 
+            _ = User.AddUser(new User("Co", "Ordinator", "coordinator"));
+            _ = User.AddUser(new User("Ad", "Min", "admin"));
+
             //Creates default roles
             _ = Role.CreateRole(new Role("Admin"));
             _ = Role.CreateRole(new Role("Coordinator"));
@@ -318,6 +321,8 @@ namespace AbetApi.Data
             _ = Role.AddRoleToUser("dr0702", "Instructor");
             _ = Role.AddRoleToUser("pls0112", "Instructor");
             _ = Role.AddRoleToUser("hw0109", "Instructor");
+            _ = Role.AddRoleToUser("coordinator", "Coordinator");
+            _ = Role.AddRoleToUser("admin", "Admin");
 
             //For testing the deep copy.
             //_ = Semester.AddSemester(new Semester("Spring", 2023));

--- a/AbetApi/Data/Database.cs
+++ b/AbetApi/Data/Database.cs
@@ -348,30 +348,30 @@ namespace AbetApi.Data
             _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "6", "CE", "2");
             _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "7", "CE", "2");
             // 2100 CE
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "1", "CE", "1");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "2", "CE", "1");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "6", "CE", "1");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "7", "CE", "1");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "3", "CE", "2");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "5", "CE", "2");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "3", "CE", "3");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "5", "CE", "3");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "3", "CE", "6");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "4", "CE", "6");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "5", "CE", "6");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "7", "CE", "7");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "1", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "2", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "6", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "7", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "3", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "5", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "3", "CE", "3");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "5", "CE", "3");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "3", "CE", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "4", "CE", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "5", "CE", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "7", "CE", "7");
             // 2110 CE
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "5", "CE", "1");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "6", "CE", "1");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "7", "CE", "1");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "1", "CE", "2");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "2", "CE", "2");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "3", "CE", "2");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "4", "CE", "2");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "1", "CE", "5");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "2", "CE", "5");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "3", "CE", "5");
-            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "4", "CE", "5");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "5", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "6", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "7", "CE", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "1", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "2", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "3", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "4", "CE", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "1", "CE", "5");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "2", "CE", "5");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "3", "CE", "5");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "4", "CE", "5");
 
             //Adds Users
             _ = User.AddUser(new User("Curtis", "Chambers", "csc0168"));

--- a/AbetApi/Data/Database.cs
+++ b/AbetApi/Data/Database.cs
@@ -43,120 +43,248 @@ namespace AbetApi.Data
 
         public void WIPDoStuff()
         {
-            _= Semester.AddSemester(new Semester("Spring", 2022));
-            _= Course.AddCourse("Spring", 2022, new Course("cas0231", "1030", "Something", "", false, "CSCE"));
-            _= Course.AddCourse("Spring", 2022, new Course("cas0231", "1040", "Something", "", false, "CSCE"));
-            _= Course.AddCourse("Spring", 2022, new Course("cas0231", "3600", "Whatever", "", false, "CSCE"));
+            /* ================= INFINITE LOOP & TEAM 27 ================= */
 
-            _= Section.AddSection("Spring", 2022, "CSCE", "1030", new Section("cas0231", false, "001", 12));
-            _= Section.AddSection("Spring", 2022, "CSCE", "1030", new Section("cas0231", false, "002", 15));
-            _= Section.AddSection("Spring", 2022, "CSCE", "1030", new Section("cas0231", false, "003", 29));
+            // create a new semester
+            _ = Semester.AddSemester(new Semester("Fall", 2022));
 
-            _= Section.AddSection("Spring", 2022, "CSCE", "1040", new Section("cas0231", false, "001", 33));
-            _= Section.AddSection("Spring", 2022, "CSCE", "1040", new Section("cas0231", false, "002", 13));
-            _= Section.AddSection("Spring", 2022, "CSCE", "1040", new Section("cas0231", false, "003", 5));
+            // add majors to semester
+            _ = Major.AddMajor("Fall", 2022, "CE");
+            _ = Major.AddMajor("Fall", 2022, "CS");
+            _ = Major.AddMajor("Fall", 2022, "IT");
 
-            _= Section.AddSection("Spring", 2022, "CSCE", "3600", new Section("cas0231", false, "001", 150));
-            _= Section.AddSection("Spring", 2022, "CSCE", "3600", new Section("cas0231", false, "002", 739));
-            _= Section.AddSection("Spring", 2022, "CSCE", "3600", new Section("cas0231", false, "003", 42));
+            // add courses to semester
+            _ = Course.AddCourse("Fall", 2022, new Course("pls0112", "1030", "Computer Science I", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("amm0813", "1030", "Computer Science I", "", false, "CSCE"));
+            //_ = Course.AddCourse("Fall", 2022, new Course("amm0813", "1030", "Computer Science I", "", false, "CSCE")); // duplicate
+            _ = Course.AddCourse("Fall", 2022, new Course("dr0702", "1030", "Computer Science I", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("bj0141", "1035", "Computer Programming I", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("dmk0080", "1040", "Computer Science II", "", false, "CSCE"));
+            //_ = Course.AddCourse("Fall", 2022, new Course("dmk0080", "1040", "Computer Science II", "", false, "CSCE")); // duplicate
+            _ = Course.AddCourse("Fall", 2022, new Course("bm0756", "1045", "Computer Programming II", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("yl0340", "2100", "Foundations of Computing", "", false, "CSCE"));
+            //_ = Course.AddCourse("Fall", 2022, new Course("yl0340", "2100", "Foundations of Computing", "", false, "CSCE")); // duplicate
+            //_ = Course.AddCourse("Fall", 2022, new Course("yl0340", "2100", "Foundations of Computing", "", false, "CSCE")); // duplicate
+            _ = Course.AddCourse("Fall", 2022, new Course("hw0109", "2100", "Foundations of Computing", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("dr0702", "2100", "Foundations of Computing", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("csc0168", "2110", "Foundations of Data Structures", "", false, "CSCE"));
+            //_ = Course.AddCourse("Fall", 2022, new Course("csc0168", "2110", "Foundations of Data Structures", "", false, "CSCE")); // duplicate
+            _ = Course.AddCourse("Fall", 2022, new Course("dr0702", "2110", "Foundations of Data Structures", "", false, "CSCE"));
 
-            _= CourseOutcome.CreateCourseOutcome("Spring", 2022, "CSCE", "1030", new CourseOutcome("1", "Some description 1"));
-            _= CourseOutcome.CreateCourseOutcome("Spring", 2022, "CSCE", "1030", new CourseOutcome("2", "Some description 2"));
-            _= CourseOutcome.CreateCourseOutcome("Spring", 2022, "CSCE", "1030", new CourseOutcome("3", "Some description 3"));
+            // add sections to courses
+            // TODO: Add number of students for each section.
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("pls0112", false, "002", 0));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("amm0813", false, "003", 0));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("amm0813", false, "004", 0));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("dr0702", false, "501", 0));
 
-            _= CourseOutcome.CreateCourseOutcome("Spring", 2022, "CSCE", "1040", new CourseOutcome("1", "Some description 1"));
-            _= CourseOutcome.CreateCourseOutcome("Spring", 2022, "CSCE", "1040", new CourseOutcome("2", "Some description 2"));
-            _= CourseOutcome.CreateCourseOutcome("Spring", 2022, "CSCE", "1040", new CourseOutcome("3", "Some description 3"));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1035", new Section("bj0141", false, "001", 0));
 
-            _= CourseOutcome.CreateCourseOutcome("Spring", 2022, "CSCE", "3600", new CourseOutcome("1", "Some description 1"));
-            _= CourseOutcome.CreateCourseOutcome("Spring", 2022, "CSCE", "3600", new CourseOutcome("2", "Some description 2"));
-            _= CourseOutcome.CreateCourseOutcome("Spring", 2022, "CSCE", "3600", new CourseOutcome("3", "Some description 3"));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1040", new Section("dmk0080", false, "001", 0));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1040", new Section("dmk0080", false, "002", 0));
 
-            _= Major.AddMajor("Spring", 2022, "CS");
-            _= Major.AddMajor("Spring", 2022, "IT");
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1045", new Section("bm0756", false, "001", 0));
 
-            _= MajorOutcome.AddMajorOutcome("Spring", 2022, "CS", new MajorOutcome("1", "Accomplishes gud at computers"));
-            _= MajorOutcome.AddMajorOutcome("Spring", 2022, "CS", new MajorOutcome("2", "Accomplishes making type fast"));
-            _= MajorOutcome.AddMajorOutcome("Spring", 2022, "CS", new MajorOutcome("3", "Accomplishes websites"));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("yl0340", false, "001", 0));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("yl0340", false, "002", 0));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("yl0340", false, "003", 0));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("hw0109", false, "004", 0));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("dr0702", false, "550", 0));
 
-            _= MajorOutcome.AddMajorOutcome("Spring", 2022, "IT", new MajorOutcome("1", "IT MO #1"));
-            _= MajorOutcome.AddMajorOutcome("Spring", 2022, "IT", new MajorOutcome("2", "IT MO #2"));
-            _= MajorOutcome.AddMajorOutcome("Spring", 2022, "IT", new MajorOutcome("3", "IT MO #3"));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2110", new Section("csc0168", false, "001", 0));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2110", new Section("csc0168", false, "002", 0));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2110", new Section("dr0702", false, "501", 0)); // missing number of students (currently 0)
 
-            _= CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "1", "CS", "1");
-            _= CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "1", "CS", "2");
-            _= CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "2", "CS", "3");
-            _= CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "3", "CS", "3");
+            // add major outcomes
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CE", new MajorOutcome("1", "An ability to identify, formulate, and solve complex engineering problems by applying principles of engineering, science, and mathematics."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CE", new MajorOutcome("2", "An ability to acquire and apply new knowledge as needed, using appropriate learning strategies."));
 
-            _= CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1040", "1", "CS", "1");
-            _= CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1040", "1", "CS", "2");
-            _= CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1040", "2", "CS", "3");
-            _= CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1040", "3", "CS", "3");
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("1", "Analyze a complex computing problem and to apply principles of computing and other relevant disciplines to identify solutions."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("2", "Design, implement, and evaluate a computing-based solution to meet a given set of computing requirements in the context of the program’s discipline."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("3", "Apply computer science theory and software development fundamentals to produce computing-based solutions."));
 
-            _= CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "3600", "1", "CS", "1");
-            _= CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "3600", "2", "CS", "2");
-            _= CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1040", "2", "CS", "3");
-            _= CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1040", "3", "CS", "3");
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "IT", new MajorOutcome("1", "Analyze a complex computing problem and to apply principles of computing and other relevant disciplines to identify solutions."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "IT", new MajorOutcome("2", "Design, implement, and evaluate a computing-based solution to meet a given set of computing requirements in the context of the program’s discipline."));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "IT", new MajorOutcome("3", "Identify and analyze user needs and to take them into account in the selection, creation, integration, evaluation, and administration of computing-based systems."));
 
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "001", "1", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "002", "1", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "003", "1", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "001", "2", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "002", "2", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "003", "2", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "001", "3", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "002", "3", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "003", "3", "CS", 10);
+            // add course outcome to course
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1030", new CourseOutcome("1", "Describe how a computer’s CPU, Main Memory, Secondary Storage and I/O work together to execute a computer program."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1030", new CourseOutcome("2", "Make use of a computer system’s hardware, editor(s), operating system, system software and network to build computer software and submit that software for grading."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1030", new CourseOutcome("3", "Describe algorithms to perform “simple” tasks such as numeric computation, searching and sorting, choosing among several options, string manipulation, and use of pseudo-random numbers in simulation of such tasks as rolling dice."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1030", new CourseOutcome("4", "Write readable, efficient and correct C/C++ programs that include programming structures such as assignment statements, selection statements, loops, arrays, pointers, console and file I/O, structures, command line arguments, both standard library and user-defined functions, and multiple header (.h) and code (.c or .cpp) files."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1030", new CourseOutcome("5", "Use commonly accepted practices and tools to find and fix runtime and logical errors in software."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1030", new CourseOutcome("6", "Describe a software process model that can be used to develop significant applications composed of hundreds of functions."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1030", new CourseOutcome("7", "Perform the steps necessary to edit, compile, link and execute C/C++ programs."));
 
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "001", "1", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "002", "1", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "003", "1", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "001", "2", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "002", "2", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "003", "2", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "001", "3", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "002", "3", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "003", "3", "CS", 10);
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1035", new CourseOutcome("1", "Describe how a computer’s CPU, Main Memory, Secondary Storage, and I/O work together to execute a computer program."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1035", new CourseOutcome("2", "Make use of a computer system’s hardware, editor(s), operating system, system software, and network to build computer software and submit that software for grading."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1035", new CourseOutcome("3", "Describe algorithms to perform \"simple\" tasks such as numeric computation, searching and sorting, choosing among several options, string manipulation, and use of pseudo-random numbers in simulation of tasks such as rolling dice."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1035", new CourseOutcome("4", "Write readable, efficient, and correct programs that include programming structures such as assignment and selection statements, loops, lists, console and file I/O, command line arguments, and both standard library and user-defined functions."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1035", new CourseOutcome("5", "Use commonly accepted practices and tools to find and fix syntax, runtime, and logical errors in software."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1035", new CourseOutcome("6", "Describe a software process model that can be used to develop significant applications composed of hundreds of functions."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1035", new CourseOutcome("7", "Perform the steps necessary to edit and execute programs."));
 
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "001", "1", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "002", "1", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "003", "1", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "001", "2", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "002", "2", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "003", "2", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "001", "3", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "002", "3", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "003", "3", "CS", 10);
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("1", "Write readable, efficient, and correct C++ programs for all programming constructs defined for Programming Fundamentals I plus dynamic memory allocation, bit manipulation operators, exceptions, classes and inheritance."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("2", "Design and implement recursive algorithms in C/C++."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("3", "Use common data structures and techniques such as stacks, queues, linked lists, trees and hashing."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("4", "Create programs using the Standard Template Library."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("5", "Use a symbolic debugger to find and fix runtime and logical errors in C software."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("6", "Using a software process model, design and implement a significant software application in C++. Significant software in this context means a software application with at least five files, ten functions and a make file."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("7", "Implement, compile and run C++ programs that includes classes, inheritance, virtual functions, function overloading and overriding, as well as other aspects of Polymorphism."));
 
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "001", "1", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "002", "1", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "003", "1", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "001", "2", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "002", "2", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "003", "2", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "001", "3", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "002", "3", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "003", "3", "IT", 10);
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1045", new CourseOutcome("1", "Write readable, efficient, and correct programs for basic programming constructs plus dynamic memory allocation, bit manipulation operators, exceptions, classes, and inheritance."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1045", new CourseOutcome("2", "Design and implement recursive algorithms using a modern programming language."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1045", new CourseOutcome("3", "Use common data structures and techniques such as stacks, queues, linked lists, trees, and hashing."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1045", new CourseOutcome("4", "Create programs using the appropriate libraries for the programming language."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1045", new CourseOutcome("5", "Use a symbolic debugger to find and fix runtime and logical errors in software."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1045", new CourseOutcome("6", "Use a software process model to design and implement a significant software application in a modern programming language consisting of multiple files and functions and a make file."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1045", new CourseOutcome("7", "Implement, compile, and run programs that include classes, inheritance, virtual functions, function overloading and overriding, as well as other aspects of polymorphism."));
 
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "001", "1", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "002", "1", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "003", "1", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "001", "2", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "002", "2", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "003", "2", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "001", "3", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "002", "3", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "003", "3", "IT", 10);
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("1", "Define and use the basic operations of sets, functions, and relations."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("2", "Define and demonstrate the basic properties of trees and graphs."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("3", "Use elementary graph and tree algorithms including traversals and searches."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("4", "Describe assertions in propositional logic form."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("5", "Describe simple circuits, I/O, and satisfiability using Boolean logic."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("6", "Use combinatorics and conditional probability in solving real-world problems."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("7", "Demonstrate a solid foundation in conceptual and formal models by describing loop structures in summation and/or product notation."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2100", new CourseOutcome("8", "Demonstrate an introductory knowledge of finite state machines."));
 
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "001", "1", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "002", "1", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "003", "1", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "001", "2", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "002", "2", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "003", "2", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "001", "3", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "002", "3", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "003", "3", "IT", 10);
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("1", "Demonstrate the ability to use Integrated Development Environments (IDE) and use formal debugging tools and techniques to develop C/C++ programs. "));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("2", "Demonstrate the ability to develop unit tests and testing strategies for C/C++ programs."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("3", "Demonstrate the ability to use code repositories for project development."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("4", "Use abstraction in the design and implementation of algorithms, such as sorting and searching algorithms."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("5", "Design and implement programming solutions to problems in C or C++."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("6", "Collaborate with other students in a team towards the design and development of programming solutions."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("7", "Use regular expressions in C/C++ programs to match patterns."));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "2110", new CourseOutcome("8", "Use of hash tables in design of software."));
+
+            // link major outcomes to course outcomes
+            // HELP: how do you guys want to link these? do we need to ask for more info?
+            //                                                courseOutcomeName ->|   mjr.   |<- majorOutcomeName
+            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "1", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "1", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "2", "CS", "3");
+            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "3", "CS", "3");
+
+
+            /* ====== END ====== INFINITE LOOP & TEAM 27 ====== END ====== */
+
+
+
+            _ = Semester.AddSemester(new Semester("Spring", 2022));
+            _ = Course.AddCourse("Spring", 2022, new Course("cas0231", "1030", "Something", "", false, "CSCE"));
+            _ = Course.AddCourse("Spring", 2022, new Course("cas0231", "1040", "Something", "", false, "CSCE"));
+            _ = Course.AddCourse("Spring", 2022, new Course("cas0231", "3600", "Whatever", "", false, "CSCE"));
+
+            _ = Section.AddSection("Spring", 2022, "CSCE", "1030", new Section("cas0231", false, "001", 12));
+            _ = Section.AddSection("Spring", 2022, "CSCE", "1030", new Section("cas0231", false, "002", 15));
+            _ = Section.AddSection("Spring", 2022, "CSCE", "1030", new Section("cas0231", false, "003", 29));
+
+            _ = Section.AddSection("Spring", 2022, "CSCE", "1040", new Section("cas0231", false, "001", 33));
+            _ = Section.AddSection("Spring", 2022, "CSCE", "1040", new Section("cas0231", false, "002", 13));
+            _ = Section.AddSection("Spring", 2022, "CSCE", "1040", new Section("cas0231", false, "003", 5));
+
+            _ = Section.AddSection("Spring", 2022, "CSCE", "3600", new Section("cas0231", false, "001", 150));
+            _ = Section.AddSection("Spring", 2022, "CSCE", "3600", new Section("cas0231", false, "002", 739));
+            _ = Section.AddSection("Spring", 2022, "CSCE", "3600", new Section("cas0231", false, "003", 42));
+
+            _ = CourseOutcome.CreateCourseOutcome("Spring", 2022, "CSCE", "1030", new CourseOutcome("1", "Some description 1"));
+            _ = CourseOutcome.CreateCourseOutcome("Spring", 2022, "CSCE", "1030", new CourseOutcome("2", "Some description 2"));
+            _ = CourseOutcome.CreateCourseOutcome("Spring", 2022, "CSCE", "1030", new CourseOutcome("3", "Some description 3"));
+
+            _ = CourseOutcome.CreateCourseOutcome("Spring", 2022, "CSCE", "1040", new CourseOutcome("1", "Some description 1"));
+            _ = CourseOutcome.CreateCourseOutcome("Spring", 2022, "CSCE", "1040", new CourseOutcome("2", "Some description 2"));
+            _ = CourseOutcome.CreateCourseOutcome("Spring", 2022, "CSCE", "1040", new CourseOutcome("3", "Some description 3"));
+
+            _ = CourseOutcome.CreateCourseOutcome("Spring", 2022, "CSCE", "3600", new CourseOutcome("1", "Some description 1"));
+            _ = CourseOutcome.CreateCourseOutcome("Spring", 2022, "CSCE", "3600", new CourseOutcome("2", "Some description 2"));
+            _ = CourseOutcome.CreateCourseOutcome("Spring", 2022, "CSCE", "3600", new CourseOutcome("3", "Some description 3"));
+
+            _ = Major.AddMajor("Spring", 2022, "CS");
+            _ = Major.AddMajor("Spring", 2022, "IT");
+
+            _ = MajorOutcome.AddMajorOutcome("Spring", 2022, "CS", new MajorOutcome("1", "Accomplishes gud at computers"));
+            _ = MajorOutcome.AddMajorOutcome("Spring", 2022, "CS", new MajorOutcome("2", "Accomplishes making type fast"));
+            _ = MajorOutcome.AddMajorOutcome("Spring", 2022, "CS", new MajorOutcome("3", "Accomplishes websites"));
+
+            _ = MajorOutcome.AddMajorOutcome("Spring", 2022, "IT", new MajorOutcome("1", "IT MO #1"));
+            _ = MajorOutcome.AddMajorOutcome("Spring", 2022, "IT", new MajorOutcome("2", "IT MO #2"));
+            _ = MajorOutcome.AddMajorOutcome("Spring", 2022, "IT", new MajorOutcome("3", "IT MO #3"));
+
+            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "1", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "1", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "2", "CS", "3");
+            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "3", "CS", "3");
+
+            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1040", "1", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1040", "1", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1040", "2", "CS", "3");
+            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1040", "3", "CS", "3");
+
+            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "3600", "1", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "3600", "2", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1040", "2", "CS", "3");
+            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1040", "3", "CS", "3");
+
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "001", "1", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "002", "1", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "003", "1", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "001", "2", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "002", "2", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "003", "2", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "001", "3", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "002", "3", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "003", "3", "CS", 10);
+
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "001", "1", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "002", "1", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "003", "1", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "001", "2", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "002", "2", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "003", "2", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "001", "3", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "002", "3", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "003", "3", "CS", 10);
+
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "001", "1", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "002", "1", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "003", "1", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "001", "2", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "002", "2", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "003", "2", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "001", "3", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "002", "3", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "003", "3", "CS", 10);
+
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "001", "1", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "002", "1", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "003", "1", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "001", "2", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "002", "2", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "003", "2", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "001", "3", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "002", "3", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1030", "003", "3", "IT", 10);
+
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "001", "1", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "002", "1", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "003", "1", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "001", "2", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "002", "2", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "003", "2", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "001", "3", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "002", "3", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "1040", "003", "3", "IT", 10);
+
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "001", "1", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "002", "1", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "003", "1", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "001", "2", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "002", "2", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "003", "2", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "001", "3", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "002", "3", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Spring", 2022, "CSCE", "3600", "003", "3", "IT", 10);
 
             //For testing the deep copy.
             //_ = Semester.AddSemester(new Semester("Fall", 2022));
@@ -171,12 +299,12 @@ namespace AbetApi.Data
             WipeTables();
 
             //Adds Users
-            _= User.AddUser(new User("Frits", "Odell", "feo0589"));
-            _= User.AddUser(new User("Clemente", "Sergei", "cas0231"));
-            
-            _= User.EditUser("feo0589", new User("Scrappy", "Eagle", "feo0589"));
+            _ = User.AddUser(new User("Frits", "Odell", "feo0589"));
+            _ = User.AddUser(new User("Clemente", "Sergei", "cas0231"));
 
-            _= User.DeleteUser("cas0231");
+            _ = User.EditUser("feo0589", new User("Scrappy", "Eagle", "feo0589"));
+
+            _ = User.DeleteUser("cas0231");
 
             //NOTES: User Crud
             //User.AddUser(new User("Frits", "Odell", "cas0231"));
@@ -185,21 +313,21 @@ namespace AbetApi.Data
             //var result = User.GetUser("cas0231").Result;
 
             //Creates default roles
-            _= Role.CreateRole(new Role("Admin"));
-            _= Role.CreateRole(new Role("Coordinator"));
-            _= Role.CreateRole(new Role("Instructor"));
-            _= Role.CreateRole(new Role("Fellow"));
-            _= Role.CreateRole(new Role("FullTime"));
-            _= Role.CreateRole(new Role("Adjunct"));
-            _= Role.CreateRole(new Role("Student"));
+            _ = Role.CreateRole(new Role("Admin"));
+            _ = Role.CreateRole(new Role("Coordinator"));
+            _ = Role.CreateRole(new Role("Instructor"));
+            _ = Role.CreateRole(new Role("Fellow"));
+            _ = Role.CreateRole(new Role("FullTime"));
+            _ = Role.CreateRole(new Role("Adjunct"));
+            _ = Role.CreateRole(new Role("Student"));
 
             //Gives admin access to:
-            _= Role.AddRoleToUser("feo0589", "Admin");
-            _= Role.AddRoleToUser("cas0231", "Admin");
+            _ = Role.AddRoleToUser("feo0589", "Admin");
+            _ = Role.AddRoleToUser("cas0231", "Admin");
 
             //Gives instructor access to:
-            _= Role.AddRoleToUser("feo0589", "Instructor");
-            _= Role.AddRoleToUser("cas0231", "Instructor");
+            _ = Role.AddRoleToUser("feo0589", "Instructor");
+            _ = Role.AddRoleToUser("cas0231", "Instructor");
 
             //this returns a list of users by the entered roll
             //var adminListTask = Role.GetUsersByRole("Admin");
@@ -210,17 +338,17 @@ namespace AbetApi.Data
             //Semester class testing
             /////////////////////////////////////////////////////////////////////////////////
             //Create
-            _= Semester.AddSemester(new Semester("Spring", 2022));
-            _= Semester.AddSemester(new Semester("Fall", 2022));
-            _= Semester.AddSemester(new Semester("Summer", 2022));
-            _= Semester.AddSemester(new Semester("Spring", 2023));
-            _= Semester.AddSemester(new Semester("Fall", 2023));
-            _= Semester.AddSemester(new Semester("Summer", 2023));
+            _ = Semester.AddSemester(new Semester("Spring", 2022));
+            _ = Semester.AddSemester(new Semester("Fall", 2022));
+            _ = Semester.AddSemester(new Semester("Summer", 2022));
+            _ = Semester.AddSemester(new Semester("Spring", 2023));
+            _ = Semester.AddSemester(new Semester("Fall", 2023));
+            _ = Semester.AddSemester(new Semester("Summer", 2023));
             //Read
             var springSemester = Semester.GetSemester("Spring", 2022);
             var fallSemester = Semester.GetSemester("Fall", 2022); // This won't work. It returns null when it can't find something
             //Update
-            _= Semester.EditSemester("Spring", 2022, new Semester("Winter", 2022));
+            _ = Semester.EditSemester("Spring", 2022, new Semester("Winter", 2022));
             //Read (again)
             springSemester = Semester.GetSemester("Spring", 2022);
             fallSemester = Semester.GetSemester("Fall", 2022);
@@ -230,9 +358,9 @@ namespace AbetApi.Data
 
             //Major class testing
             /////////////////////////////////////////////////////////////////////////////////
-            _= Major.AddMajor("Fall", 2022, "CS");
-            _= Major.AddMajor("Fall", 2022, "IT");
-            _= Major.AddMajor("Fall", 2022, "CYS");
+            _ = Major.AddMajor("Fall", 2022, "CS");
+            _ = Major.AddMajor("Fall", 2022, "IT");
+            _ = Major.AddMajor("Fall", 2022, "CYS");
             //var temp = Major.GetMajor("Fall", 2022, "CS");
             //temp = Major.GetMajor("Fall", 2022, "CSE"); // return null
             //Major.EditMajor("Fall", 2022, "CS", new Major("IT"));
@@ -241,19 +369,19 @@ namespace AbetApi.Data
 
             //MajorOutcome class testing
             /////////////////////////////////////////////////////////////////////////////////
-            _= MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("1", "Accomplishes gud at computers"));
-            _= MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("2", "Accomplishes making type fast"));
-            _= MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("3", "Accomplishes websites"));
-            var tempMajorOutcome =  MajorOutcome.GetMajorOutcome("Fall", 2022, "CS", "2");
-            _= MajorOutcome.EditMajorOutcome("Fall", 2022, "CS", "3", new MajorOutcome("3", "Gud at spelung"));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("1", "Accomplishes gud at computers"));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("2", "Accomplishes making type fast"));
+            _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CS", new MajorOutcome("3", "Accomplishes websites"));
+            var tempMajorOutcome = MajorOutcome.GetMajorOutcome("Fall", 2022, "CS", "2");
+            _ = MajorOutcome.EditMajorOutcome("Fall", 2022, "CS", "3", new MajorOutcome("3", "Gud at spelung"));
             //MajorOutcome.DeleteMajorOutcome("Fall", 2022, "CS", "3");
 
             System.Console.WriteLine("");
 
             //Course class testing
             /////////////////////////////////////////////////////////////////////////////////
-            _= Course.AddCourse("Fall", 2022, new Course("cas0231", "3600", "Whatever", "", false, "CSCE"));
-            _= Course.AddCourse("Fall", 2022, new Course("cas0231", "1040", "Something", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("cas0231", "3600", "Whatever", "", false, "CSCE"));
+            _ = Course.AddCourse("Fall", 2022, new Course("cas0231", "1040", "Something", "", false, "CSCE"));
             //var course = Course.GetCourse("Fall", 2022, "CSCE", "3600"); // This is an example of a get function that loads one of the lists
             //var tempSemester = Semester.GetSemester("Fall", 2022); // This is a dumb get function, that only returns exactly what you ask for without the lists
 
@@ -266,30 +394,30 @@ namespace AbetApi.Data
 
             //Section class testing
             /////////////////////////////////////////////////////////////////////////////////
-            _= Section.AddSection("Fall", 2022, "CSCE", "3600", new Section("cas0231", false, "001", 150));
-            _= Section.AddSection("Fall", 2022, "CSCE", "3600", new Section("cas0231", false, "002", 739));
-            _= Section.AddSection("Fall", 2022, "CSCE", "3600", new Section("cas0231", false, "003", 42));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "3600", new Section("cas0231", false, "001", 150));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "3600", new Section("cas0231", false, "002", 739));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "3600", new Section("cas0231", false, "003", 42));
             //var temp = Course.GetSections("Fall", 2022, "CSCE", "3600");
             //var temp = Section.GetSection("Fall", 2022, "CSCE", "3600", "001");
-            _= Section.EditSection("Fall", 2022, "CSCE", "3600", "002", new Section("cas0231", true, "002", 140));
-            _= Section.DeleteSection("Fall", 2022, "CSCE", "3600", "001");
+            _ = Section.EditSection("Fall", 2022, "CSCE", "3600", "002", new Section("cas0231", true, "002", 140));
+            _ = Section.DeleteSection("Fall", 2022, "CSCE", "3600", "001");
 
 
             //CourseOutcome class testing
             /////////////////////////////////////////////////////////////////////////////////
-            _= CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "3600", new CourseOutcome("1", "Some description 1"));
-            _= CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "3600", new CourseOutcome("2", "Some description 2"));
-            _= CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("1", "Some description 1"));
-            _= CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("2", "Some description 2"));
-            _= CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("2", "Some different description 2")); // This overwrites the other 2 for this course
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "3600", new CourseOutcome("1", "Some description 1"));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "3600", new CourseOutcome("2", "Some description 2"));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("1", "Some description 1"));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("2", "Some description 2"));
+            _ = CourseOutcome.CreateCourseOutcome("Fall", 2022, "CSCE", "1040", new CourseOutcome("2", "Some different description 2")); // This overwrites the other 2 for this course
 
             //CourseOutcome.AddMajorOutcome("Fall", 2022, "CSCE", "3600", "CS", "739");// These next 3 will not work
             //CourseOutcome.AddMajorOutcome("Fall", 2022, "CSCE", "3600", "CS", "22");
             //CourseOutcome.AddMajorOutcome("Fall", 2022, "CSCE", "1040", "CS", "42");
-            _= CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040","2", "CS", "1"); // This one should work
-            _= CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "1", "CS", "2");
-            _= CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "3600", "1", "CS", "1");
-            _= CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "3600", "2", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "2", "CS", "1"); // This one should work
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "1", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "3600", "1", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "3600", "2", "CS", "2");
 
             System.Console.WriteLine("");
 
@@ -304,14 +432,14 @@ namespace AbetApi.Data
             List<Grade> grades = new List<Grade>();
             grades.Add(new Grade("CSCE", 1, 2, 3, 4, 5, 6, 7, 666));
             grades.Add(new Grade("EENG", 8, 9, 10, 11, 12, 13, 14, 999));
-            _= Grade.SetGrades("Fall", 2022, "CSCE", "3600", "002", grades);
+            _ = Grade.SetGrades("Fall", 2022, "CSCE", "3600", "002", grades);
 
 
             //Testing section for StudentOutcomesCompleted
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Fall", 2022, "CSCE", "3600", "002", "1", "CS", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Fall", 2022, "CSCE", "3600", "002", "2", "IT", 20);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Fall", 2022, "CSCE", "3600", "002", "1", "IT", 10);
-            _= StudentOutcomesCompleted.SetStudentOutcomesCompleted("Fall", 2022, "CSCE", "3600", "002", "2", "CS", 20);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Fall", 2022, "CSCE", "3600", "002", "1", "CS", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Fall", 2022, "CSCE", "3600", "002", "2", "IT", 20);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Fall", 2022, "CSCE", "3600", "002", "1", "IT", 10);
+            _ = StudentOutcomesCompleted.SetStudentOutcomesCompleted("Fall", 2022, "CSCE", "3600", "002", "2", "CS", 20);
 
             var temp = StudentOutcomesCompleted.GetStudentOutcomesCompleted("Fall", 2022, "CSCE", "3600", "002");
 

--- a/AbetApi/Data/Database.cs
+++ b/AbetApi/Data/Database.cs
@@ -179,19 +179,14 @@ namespace AbetApi.Data
             // add courses to semester
             _ = Course.AddCourse("Fall", 2022, new Course("coordinator", "1030", "Computer Science I", "", false, "CSCE"));
             _ = Course.AddCourse("Fall", 2022, new Course("coordinator", "1030", "Computer Science I", "", false, "CSCE"));
-            //_ = Course.AddCourse("Fall", 2022, new Course("amm0813", "1030", "Computer Science I", "", false, "CSCE")); // duplicate
             _ = Course.AddCourse("Fall", 2022, new Course("coordinator", "1030", "Computer Science I", "", false, "CSCE"));
             _ = Course.AddCourse("Fall", 2022, new Course("coordinator", "1035", "Computer Programming I", "", false, "CSCE"));
             _ = Course.AddCourse("Fall", 2022, new Course("coordinator", "1040", "Computer Science II", "", false, "CSCE"));
-            //_ = Course.AddCourse("Fall", 2022, new Course("dmk0080", "1040", "Computer Science II", "", false, "CSCE")); // duplicate
             _ = Course.AddCourse("Fall", 2022, new Course("coordinator", "1045", "Computer Programming II", "", false, "CSCE"));
             _ = Course.AddCourse("Fall", 2022, new Course("coordinator", "2100", "Foundations of Computing", "", false, "CSCE"));
-            //_ = Course.AddCourse("Fall", 2022, new Course("yl0340", "2100", "Foundations of Computing", "", false, "CSCE")); // duplicate
-            //_ = Course.AddCourse("Fall", 2022, new Course("yl0340", "2100", "Foundations of Computing", "", false, "CSCE")); // duplicate
             _ = Course.AddCourse("Fall", 2022, new Course("coordinator", "2100", "Foundations of Computing", "", false, "CSCE"));
             _ = Course.AddCourse("Fall", 2022, new Course("coordinator", "2100", "Foundations of Computing", "", false, "CSCE"));
             _ = Course.AddCourse("Fall", 2022, new Course("coordinator", "2110", "Foundations of Data Structures", "", false, "CSCE"));
-            //_ = Course.AddCourse("Fall", 2022, new Course("csc0168", "2110", "Foundations of Data Structures", "", false, "CSCE")); // duplicate
             _ = Course.AddCourse("Fall", 2022, new Course("coordinator", "2110", "Foundations of Data Structures", "", false, "CSCE"));
 
             // add sections to courses

--- a/AbetApi/Data/Database.cs
+++ b/AbetApi/Data/Database.cs
@@ -43,6 +43,7 @@ namespace AbetApi.Data
 
         public void WIPDoStuff()
         {
+
             /*
             _ = Semester.AddSemester(new Semester("Spring", 2022));
             _ = Course.AddCourse("Spring", 2022, new Course("cas0231", "1030", "Something", "", false, "CSCE"));
@@ -163,9 +164,9 @@ namespace AbetApi.Data
             //_ = Semester.AddSemester(new Semester("Fall", 2022));
             //Semester.DeepCopy("Fall", 2022, "Spring", 2022);
 
-            //WipeTables();
-
             /* ================= INFINITE LOOP & TEAM 27 ================= */
+
+            WipeTables();
 
             // create a new semester
             _ = Semester.AddSemester(new Semester("Fall", 2022));

--- a/AbetApi/Data/Database.cs
+++ b/AbetApi/Data/Database.cs
@@ -284,10 +284,10 @@ namespace AbetApi.Data
             // link major outcomes to course outcomes
             // HELP: how do you guys want to link these? do we need to ask for more info?
             //                                                courseOutcomeName ->|   mjr.   |<- majorOutcomeName
-            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "1", "CS", "1");
-            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "1", "CS", "2");
-            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "2", "CS", "3");
-            _ = CourseOutcome.LinkToMajorOutcome("Spring", 2022, "CSCE", "1030", "3", "CS", "3");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "1", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "1", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "2", "CS", "3");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "3", "CS", "3");
 
             //Adds Users
             _ = User.AddUser(new User("Curtis", "Chambers", "csc0168"));

--- a/AbetApi/Data/Database.cs
+++ b/AbetApi/Data/Database.cs
@@ -438,6 +438,78 @@ namespace AbetApi.Data
             _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "5", "CS", "6");
             _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "6", "CS", "6");
 
+            // 1030 IT
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "3", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "4", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "7", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "1", "IT", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "2", "IT", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "5", "IT", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "6", "IT", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "7", "IT", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "3", "IT", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "4", "IT", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "7", "IT", "6");
+            // 1035 IT
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "3", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "4", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "7", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "1", "IT", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "2", "IT", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "5", "IT", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "6", "IT", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "7", "IT", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "3", "IT", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "4", "IT", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "7", "IT", "6");
+            // 1040 IT
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "1", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "2", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "3", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "4", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "5", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "6", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "7", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "2", "IT", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "6", "IT", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "7", "IT", "2"); 
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "6", "IT", "6");
+            // 1045 IT
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "1", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "2", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "3", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "4", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "5", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "6", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "7", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "2", "IT", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "6", "IT", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "7", "IT", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "6", "IT", "6");
+            // 2100 IT
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "1", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "2", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "4", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "5", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "7", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "8", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "3", "IT", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "6", "IT", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "7", "IT", "3");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "3", "IT", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "6", "IT", "6");
+            // 2110 IT
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "4", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "7", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "8", "IT", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "4", "IT", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "5", "IT", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "1", "IT", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "2", "IT", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "3", "IT", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "5", "IT", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "6", "IT", "6");
+
             //Adds Users
             _ = User.AddUser(new User("Curtis", "Chambers", "csc0168"));
             _ = User.AddUser(new User("Beilei", "Jiang", "bj0141"));

--- a/AbetApi/Data/Database.cs
+++ b/AbetApi/Data/Database.cs
@@ -72,28 +72,28 @@ namespace AbetApi.Data
             _ = Course.AddCourse("Fall", 2022, new Course("dr0702", "2110", "Foundations of Data Structures", "", false, "CSCE"));
 
             // add sections to courses
-            // TODO: Add number of students for each section.
-            _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("pls0112", false, "002", 0));
-            _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("amm0813", false, "003", 0));
-            _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("amm0813", false, "004", 0));
-            _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("dr0702", false, "501", 0));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("pls0112", false, "001", 120));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("pls0112", false, "002", 120));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("amm0813", false, "003", 130));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("amm0813", false, "004", 94));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1030", new Section("dr0702", false, "501", 25));
 
-            _ = Section.AddSection("Fall", 2022, "CSCE", "1035", new Section("bj0141", false, "001", 0));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1035", new Section("bj0141", false, "001", 32));
 
-            _ = Section.AddSection("Fall", 2022, "CSCE", "1040", new Section("dmk0080", false, "001", 0));
-            _ = Section.AddSection("Fall", 2022, "CSCE", "1040", new Section("dmk0080", false, "002", 0));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1040", new Section("dmk0080", false, "001", 118));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1040", new Section("dmk0080", false, "002", 118));
 
-            _ = Section.AddSection("Fall", 2022, "CSCE", "1045", new Section("bm0756", false, "001", 0));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "1045", new Section("bm0756", false, "001", 32));
 
-            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("yl0340", false, "001", 0));
-            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("yl0340", false, "002", 0));
-            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("yl0340", false, "003", 0));
-            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("hw0109", false, "004", 0));
-            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("dr0702", false, "550", 0));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("yl0340", false, "001", 75));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("yl0340", false, "002", 75));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("yl0340", false, "003", 68));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("hw0109", false, "004", 95));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2100", new Section("dr0702", false, "550", 40));
 
-            _ = Section.AddSection("Fall", 2022, "CSCE", "2110", new Section("csc0168", false, "001", 0));
-            _ = Section.AddSection("Fall", 2022, "CSCE", "2110", new Section("csc0168", false, "002", 0));
-            _ = Section.AddSection("Fall", 2022, "CSCE", "2110", new Section("dr0702", false, "501", 0)); // missing number of students (currently 0)
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2110", new Section("csc0168", false, "001", 110));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2110", new Section("csc0168", false, "002", 110));
+            _ = Section.AddSection("Fall", 2022, "CSCE", "2110", new Section("dr0702", false, "501", 40)); // missing number of students (currently 0)
 
             // add major outcomes
             _ = MajorOutcome.AddMajorOutcome("Fall", 2022, "CE", new MajorOutcome("1", "An ability to identify, formulate, and solve complex engineering problems by applying principles of engineering, science, and mathematics."));

--- a/AbetApi/Data/Database.cs
+++ b/AbetApi/Data/Database.cs
@@ -372,6 +372,71 @@ namespace AbetApi.Data
             _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "2", "CE", "5");
             _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "3", "CE", "5");
             _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "4", "CE", "5");
+            // 1030 CS
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "3", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "4", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "1", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "2", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "5", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "6", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "7", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "3", "CS", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "4", "CS", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1030", "7", "CS", "6");
+            // 1035 CS
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "3", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "4", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "1", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "2", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "5", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "6", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "7", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "3", "CS", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "4", "CS", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1035", "7", "CS", "6");
+            // 1040 CS
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "2", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "5", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "1", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "3", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "4", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "6", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "7", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "2", "CS", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1040", "3", "CS", "6");
+            // 1045 CS
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "2", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "5", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "1", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "3", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "4", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "6", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "7", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "2", "CS", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "1045", "3", "CS", "6");
+            // 2100 CS
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "1", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "2", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "4", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "5", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "7", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "8", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "3", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "6", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "7", "CS", "3");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "3", "CS", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2100", "6", "CS", "6");
+            // 2110 CS
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "4", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "7", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "8", "CS", "1");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "4", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "5", "CS", "2");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "1", "CS", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "2", "CS", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "3", "CS", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "5", "CS", "6");
+            _ = CourseOutcome.LinkToMajorOutcome("Fall", 2022, "CSCE", "2110", "6", "CS", "6");
 
             //Adds Users
             _ = User.AddUser(new User("Curtis", "Chambers", "csc0168"));

--- a/AbetApi/EFModels/Course.cs
+++ b/AbetApi/EFModels/Course.cs
@@ -267,10 +267,10 @@ namespace AbetApi.EFModels
                 foreach (Course course in semester.Courses)
                 {
                     //Check for duplicates.
-                    if (course.CourseNumber == NewValue.CourseNumber)
-                    {
-                        throw new ArgumentException("That course number already exists in the database.");
-                    }
+                    //if (course.CourseNumber == NewValue.CourseNumber)
+                    //{
+                    //    throw new ArgumentException("That course number already exists in the database.");
+                    //}
 
                     if (course.Department == department && course.CourseNumber == courseNumber)
                     {

--- a/AbetApi/EFModels/CourseOutcome.cs
+++ b/AbetApi/EFModels/CourseOutcome.cs
@@ -761,13 +761,13 @@ namespace AbetApi.EFModels
                 //Load the links between a course outcome and major outcomes.
                 context.Entry(tempCourseOutcome).Collection(courseOutcome => courseOutcome.MajorOutcomes).Load();
 
-                foreach (MajorOutcome majorOutcome in tempCourseOutcome.MajorOutcomes)
-                {
-                    if(majorOutcome.Name == majorOutcomeName)
-                    {
-                        throw new ArgumentException("The course outcome specified already has a link to the major outcome specified.");
-                    }
-                }
+                //foreach (MajorOutcome majorOutcome in tempCourseOutcome.MajorOutcomes)
+                //{
+                //    if(majorOutcome.Name == majorOutcomeName)
+                //    {
+                //        throw new ArgumentException("The course outcome specified already has a link to the major outcome specified.");
+                //    }
+                //}
                 
                 //Adds the outcome designator to the course outcomes
                 tempCourseOutcome.MajorOutcomes.Add(tempMajorOutcome);

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Each term, students and faculty enter data for each course they are enrolled in/
 This is the _back-end_ for the Fall 2020 - Spring 2023 UNT ABET Course Assessment Tool project.
 
 ## Getting Started
-This is a [.NET]() project written using C#. It uses Microsoft IIS Express to create and host a web server for the backend.
+This is a [.NET](https://dotnet.microsoft.com/en-US/) project written using C#. It uses Microsoft IIS Express to create and host a web server for the backend.
 
-Download and unzip the project. Open the the AbetApi folder and open the Solution file in Microsoft Visual Studio 2019/2022. When the project is loaded, in the ribbon, click the green arrow next to IIS Express. This will start the local IIS web server and the browser will open to a Swagger page with debug commands.
+Download and unzip the project. Open the the AbetApi folder and open the Solution file in Microsoft Visual Studio 2019/2022. When the project is loaded, in the ribbon, click the green arrow next to "IIS Express" to run. This will start the local IIS web server and the browser will open to a Swagger page with debug commands.
 
-Now that the back end web server is running, start the [front end](https://github.com/huynggg/Abet-Course-Assessment-Tool-Frontend).
+Now that the back-end web server is running, start the [front end](https://github.com/huynggg/Abet-Course-Assessment-Tool-Frontend).
 Open [http://localhost:3000](http://127.0.0.1:3000) in your browser to see the result.
 
-This project uses MySQL Workbench and MySQL Server for the database to connect to the backend. Download MySQL Installer Community to install and configure both MySQL applications at the same location. Make sure the root password set in the MySQL Server configuration is the same as the password in the file appsettings.json. That file is located in the AbetApi folder within the backend.
+This project uses [MySQL Workbench](https://dev.mysql.com/downloads/workbench/) and MySQL Server for the database to connect to the backend. Download MySQL Installer Community to install and configure both MySQL applications at the same location. Make sure the root password set in the MySQL Server configuration is the same as the password in the file appsettings.json. That file is located in the AbetApi folder within the backend.
 
 In order to login after all of the above has been completed, you must be connected to a UNT network with their vpn to have sign in using your EUID and password.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # ABET_Course_Assessment_Tool
-Capstone project Spring '21
+Capstone project Fall 2022

--- a/README.md
+++ b/README.md
@@ -12,4 +12,6 @@ Download and unzip the project. Open the the AbetApi folder and open the Solutio
 Now that the back end web server is running, start the [front end](https://github.com/huynggg/Abet-Course-Assessment-Tool-Frontend).
 Open [http://localhost:3000](http://127.0.0.1:3000) in your browser to see the result.
 
-In order to login, you must be connected to a UNT network and have valid EUID to login.
+This project uses MySQL Workbench and MySQL Server for the database to connect to the backend. Download MySQL Installer Community to install and configure both MySQL applications at the same location. Make sure the root password set in the MySQL Server configuration is the same as the password in the file appsettings.json. That file is located in the AbetApi folder within the backend.
+
+In order to login after all of the above has been completed, you must be connected to a UNT network with their vpn to have sign in using your EUID and password.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Each term, students and faculty enter data for each course they are enrolled in/teach in the CSE department. This data is used to assess the department courses for ABET accreditation. Near the end of the term, students are given a link where they assess their CSE courses based on pre-specified course outcomes. After the course is completed, instructors have data (including attachments) that are provided. Reports are provided to the department Undergrad Curriculum Committee and the Undergraduate Coordinator so that the courses can be assessed according to the course and relevant program outcomes. There is a current system, which is hard to use and hard to maintain. The program outcome mappings are obsolete due to ABET changes, so a new version is needed.
 
-This is the _back-end_ for the Fall 2020 - Spring 2022 UNT ABET Course Assessment Tool project.
+This is the _back-end_ for the Fall 2020 - Spring 2023 UNT ABET Course Assessment Tool project.
 
 ## Getting Started
 This is a [.NET]() project written using C#. It uses Microsoft IIS Express to create and host a web server for the backend.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# ABET_Course_Assessment_Tool
-Capstone project Fall 2022
+# Description
+
+Each term, students and faculty enter data for each course they are enrolled in/teach in the CSE department. This data is used to assess the department courses for ABET accreditation. Near the end of the term, students are given a link where they assess their CSE courses based on pre-specified course outcomes. After the course is completed, instructors have data (including attachments) that are provided. Reports are provided to the department Undergrad Curriculum Committee and the Undergraduate Coordinator so that the courses can be assessed according to the course and relevant program outcomes. There is a current system, which is hard to use and hard to maintain. The program outcome mappings are obsolete due to ABET changes, so a new version is needed.
+
+This is the _back-end_ for the Fall 2020 - Spring 2022 UNT ABET Course Assessment Tool project.
+
+## Getting Started
+This is a [.NET]() project written using C#. It uses Microsoft IIS Express to create and host a web server for the backend.
+
+Download and unzip the project. Open the the AbetApi folder and open the Solution file in Microsoft Visual Studio 2019/2022. When the project is loaded, in the ribbon, click the green arrow next to IIS Express. This will start the local IIS web server and the browser will open to a Swagger page with debug commands.
+
+Now that the back end web server is running, start the [front end](https://github.com/huynggg/Abet-Course-Assessment-Tool-Frontend).
+Open [http://localhost:3000](http://127.0.0.1:3000) in your browser to see the result.
+
+In order to login, you must be connected to a UNT network and have valid EUID to login.


### PR DESCRIPTION
Database now should load with accurate course information for the selected courses, including sections, professor EUIDs, and seat numbers. This should not affect the functionality of the application, only the data.

You may want to modify the `CourseOutcome.LinkToMajorOutcome(...)` lines before approving, because I am not sure how we are supposed to map those.
Currently, I left the previous teams' test data in including the outcomes like "make gud at computers", and courses like CSCE 3600. We can have that removed if you want.

Let me know if I need to make any changes, or you can make them yourself if you want to.