### PR TITLE
Security patch

### DIFF
--- a/AbetApi/Controllers/Authentication.cs
+++ b/AbetApi/Controllers/Authentication.cs
@@ -24,7 +24,7 @@ namespace AbetApi.Controllers
         }
 
         // This function is used to return a token that contains all of the roles a user has after successfully logging in
-        [HttpPost("Login")]
+        [HttpPost("Login")] // Frontend caller: API.login()
         public ActionResult Login([FromBody] AxiosRequest.Login request)
         {
 

--- a/AbetApi/Controllers/Authentication.cs
+++ b/AbetApi/Controllers/Authentication.cs
@@ -9,6 +9,7 @@ using Microsoft.IdentityModel.Tokens;
 using AbetApi.Authentication;
 using System.Text;
 using Microsoft.AspNetCore.Http;
+using AbetApi.EFModels;
 
 namespace AbetApi.Controllers
 {
@@ -22,15 +23,9 @@ namespace AbetApi.Controllers
             this.tokenGenerator = tokenGenerator;
         }
 
-        public class Login_Request
-        {
-            public string euid { get; set; }
-            public string password { get; set; }
-        }
-
         // This function is used to return a token that contains all of the roles a user has after successfully logging in
         [HttpPost("Login")]
-        public ActionResult Login([FromBody] Login_Request request)
+        public ActionResult Login([FromBody] AxiosRequest.Login request)
         {
 
             string euid = request.euid;

--- a/AbetApi/Controllers/Authentication.cs
+++ b/AbetApi/Controllers/Authentication.cs
@@ -22,7 +22,7 @@ namespace AbetApi.Controllers
             this.tokenGenerator = tokenGenerator;
         }
 
-        public class LoginRequest
+        public class Login_Request
         {
             public string euid { get; set; }
             public string password { get; set; }
@@ -30,7 +30,7 @@ namespace AbetApi.Controllers
 
         // This function is used to return a token that contains all of the roles a user has after successfully logging in
         [HttpPost("Login")]
-        public ActionResult Login([FromBody] LoginRequest request)
+        public ActionResult Login([FromBody] Login_Request request)
         {
 
             string euid = request.euid;

--- a/AbetApi/Controllers/RoleController.cs
+++ b/AbetApi/Controllers/RoleController.cs
@@ -86,7 +86,7 @@ namespace AbetApi.Controllers
             {
                 return BadRequest(ex.Message);
             }
-        } // DeleteRole
+        }// DeleteRole
 
         // This function adds the provided role to the given user (via EUID)
         [Authorize(Roles = RoleTypes.Admin)]
@@ -107,11 +107,11 @@ namespace AbetApi.Controllers
         // This function removes the selected role from the selected user (via EUID)
         [Authorize(Roles = RoleTypes.Admin)]
         [HttpDelete("RemoveRoleFromUser")]
-        public async Task<IActionResult> RemoveRoleFromUser(string EUID, string roleName)
+        public async Task<IActionResult> RemoveRoleFromUser([FromBody]AxiosRequest.RemoveRoleFromUser request)
         {
             try
             {
-                await Role.RemoveRoleFromUser(EUID, roleName);
+                await Role.RemoveRoleFromUser(request);
                 return Ok();
             }
             catch (Exception ex)

--- a/AbetApi/Controllers/UsersController.cs
+++ b/AbetApi/Controllers/UsersController.cs
@@ -66,8 +66,8 @@ namespace AbetApi.Controllers
             }
         } // AddUser
 
-        [Authorize(Roles = RoleTypes.Admin)]
-        [HttpDelete("DeleteUser")]
+        [Authorize(Roles = RoleTypes.Admin)] // Require Admin role for this action
+        [HttpDelete("DeleteUser")] // Frontend caller: API.deleteFacultyUser()
         //! The DeleteUser function
         /*! 
          * This function deletes a user's profile from the databse. Utilizes EFModels.User in EFModels.
@@ -88,8 +88,8 @@ namespace AbetApi.Controllers
             }
         } // DeleteUser
 
-        [Authorize(Roles = RoleTypes.Admin)]
-        [HttpPatch("EditUser")]
+        [Authorize(Roles = RoleTypes.Admin)] // Require Admin role for this action
+        [HttpPatch("EditUser")] // Frontend caller: API.editFacultyUser()
         //! The EditUser function
         /*! 
          * This function updates a user with the provided information. Utilizes EFModels.User in EFModels.
@@ -111,8 +111,8 @@ namespace AbetApi.Controllers
             }
         } // EditUser
 
-        [Authorize(Roles = RoleTypes.Admin)]
-        [HttpPost("AddUserWithRoles")]
+        [Authorize(Roles = RoleTypes.Admin)] // Require Admin role for this action
+        [HttpPost("AddUserWithRoles")] // Frontend caller: API.addFacultyMember()
         //! AddUserWithRoles function
         /*! 
          * This function creates a user with the provided information (Has roles associated already). Utilizes Models.UserWithRoles in Models.

--- a/AbetApi/EFModels/AxiosRequest.cs
+++ b/AbetApi/EFModels/AxiosRequest.cs
@@ -33,8 +33,8 @@
         }
         public class EditUser
         {
-            string EUID { get; set; }
-            User NewUserInfo { get; set; }
+            public string EUID { get; set; }
+            public User NewUserInfo { get; set; }
         }
     }
 }

--- a/AbetApi/EFModels/AxiosRequest.cs
+++ b/AbetApi/EFModels/AxiosRequest.cs
@@ -1,0 +1,35 @@
+﻿namespace AbetApi.EFModels
+{
+    public class AxiosRequest
+    {
+        public class Login
+        {
+            public string euid { get; set; }
+            public string password { get; set; }
+        }
+
+        /// The following requests are using in <see cref="Role"/>
+        public class CreateRole
+        {
+            public Role role { get; set; }
+        }
+        public class AddRoleToUser
+        {
+            public string EUID { get; set; }
+            public string roleName { get; set; }
+        }
+        public class GetUsersByRole
+        {
+            public string roleName { get; set; }
+        }
+        public class DeleteRole
+        {
+            public string roleName { get; set; }
+        }
+        public class RemoveRoleFromUser
+        {
+            public string EUID { get; set; }
+            public string roleName { get; set; }
+        }
+    }
+}

--- a/AbetApi/EFModels/AxiosRequest.cs
+++ b/AbetApi/EFModels/AxiosRequest.cs
@@ -31,5 +31,10 @@
             public string EUID { get; set; }
             public string roleName { get; set; }
         }
+        public class EditUser
+        {
+            string EUID { get; set; }
+            User NewUserInfo { get; set; }
+        }
     }
 }

--- a/AbetApi/EFModels/AxiosRequest.cs
+++ b/AbetApi/EFModels/AxiosRequest.cs
@@ -36,5 +36,9 @@
             public string EUID { get; set; }
             public User NewUserInfo { get; set; }
         }
+        public class DeleteUser
+        {
+            public string euid { get; set; }
+        }
     }
 }

--- a/AbetApi/EFModels/Role.cs
+++ b/AbetApi/EFModels/Role.cs
@@ -25,13 +25,9 @@ namespace AbetApi.EFModels
             this.Name = Name;
         }
 
-        public class CreateRole_Request
-        {
-            public Role role { get; set; }
-        }
         // This function creates a role with the given name
         // Naming convention is the role name starting with uppercase
-        public static async Task CreateRole([FromBody] CreateRole_Request request)
+        public static async Task CreateRole([FromBody] AxiosRequest.CreateRole request)
         {
             //Role role = new Role();
             Role role = request.role; //?
@@ -62,13 +58,8 @@ namespace AbetApi.EFModels
             }
         } // CreateRole
 
-        public class AddRoleToUser_Request
-        {
-            public string EUID { get; set; }
-            public string roleName { get; set; }
-        }
         // This function gives a selected user a provided role.
-        public async static Task AddRoleToUser([FromBody] AddRoleToUser_Request request)
+        public async static Task AddRoleToUser([FromBody] AxiosRequest.AddRoleToUser request)
         {
             string EUID = request.EUID;
             string roleName = request.roleName;
@@ -185,12 +176,8 @@ namespace AbetApi.EFModels
             }
         }
 
-        public class GetUsersByRole_Request
-        {
-            public string roleName { get; set; }
-        }
         // Gets a list of users with the selected role
-        public static async Task<List<User>> GetUsersByRole([FromBody] GetUsersByRole_Request request)
+        public static async Task<List<User>> GetUsersByRole([FromBody] AxiosRequest.GetUsersByRole request)
         {
             string roleName = request.roleName;
 
@@ -223,12 +210,8 @@ namespace AbetApi.EFModels
         } // GetUsersByRole
 
 
-        public class DeleteRole_Request
-        {
-            public string roleName { get; set; }
-        }
         // This function deletes a selected role
-        public static async Task DeleteRole([FromBody] DeleteRole_Request request)
+        public static async Task DeleteRole([FromBody] AxiosRequest.DeleteRole request)
         {
             string roleName = request.roleName;
 
@@ -259,13 +242,8 @@ namespace AbetApi.EFModels
         } // DeleteRole
 
 
-        public class RemoveRoleFromUser_Request
-        {
-            public string EUID { get; set; }
-            public string roleName { get; set; }
-        }
         // This function removes a role from a user, selected via EUID
-        public async static Task RemoveRoleFromUser([FromBody] RemoveRoleFromUser_Request request)
+        public async static Task RemoveRoleFromUser([FromBody] AxiosRequest.RemoveRoleFromUser request)
         {
             string EUID = request.EUID;
             string roleName = request.roleName;

--- a/AbetApi/EFModels/Role.cs
+++ b/AbetApi/EFModels/Role.cs
@@ -174,7 +174,7 @@ namespace AbetApi.EFModels
                 role.Users.Add(user);
                 context.SaveChanges();
             }
-        }
+        } // AddRoleToUser
 
         // Gets a list of users with the selected role
         public static async Task<List<User>> GetUsersByRole([FromBody] AxiosRequest.GetUsersByRole request)

--- a/AbetApi/EFModels/Role.cs
+++ b/AbetApi/EFModels/Role.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using AbetApi.Data;
 using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Mvc;
+using static AbetApi.Controllers.Authentication;
 
 namespace AbetApi.EFModels
 {
@@ -23,10 +25,17 @@ namespace AbetApi.EFModels
             this.Name = Name;
         }
 
+        public class CreateRole_Request
+        {
+            public Role role { get; set; }
+        }
         // This function creates a role with the given name
         // Naming convention is the role name starting with uppercase
-        public static async Task CreateRole(Role role)
+        public static async Task CreateRole([FromBody] CreateRole_Request request)
         {
+            //Role role = new Role();
+            Role role = request.role; //?
+
             //Check that the role name is not null or empty.
             if (role.Name == null || role.Name == "")
             {
@@ -53,9 +62,17 @@ namespace AbetApi.EFModels
             }
         } // CreateRole
 
-        // This function gives a selected user a provided role.
-        public async static Task AddRoleToUser(string EUID, string roleName)
+        public class AddRoleToUser_Request
         {
+            public string EUID { get; set; }
+            public string roleName { get; set; }
+        }
+        // This function gives a selected user a provided role.
+        public async static Task AddRoleToUser([FromBody] AddRoleToUser_Request request)
+        {
+            string EUID = request.EUID;
+            string roleName = request.roleName;
+
             //Check that the EUID of the user is not null or empty.
             if (EUID == null || EUID == "")
             {
@@ -110,9 +127,16 @@ namespace AbetApi.EFModels
             }
         } // AddRoleToUser
 
-        // Gets a list of users with the selected role
-        public static async Task<List<User>> GetUsersByRole(string roleName)
+
+        public class GetUsersByRole_Request
         {
+            public string roleName { get; set; }
+        }
+        // Gets a list of users with the selected role
+        public static async Task<List<User>> GetUsersByRole([FromBody] GetUsersByRole_Request request)
+        {
+            string roleName = request.roleName;
+
             //Check that the role name is not null or empty.
             if (roleName == null || roleName == "")
             {
@@ -141,9 +165,16 @@ namespace AbetApi.EFModels
             }
         } // GetUsersByRole
 
-        // This function deletes a selected role
-        public static async Task DeleteRole(string roleName)
+
+        public class DeleteRole_Request
         {
+            public string roleName { get; set; }
+        }
+        // This function deletes a selected role
+        public static async Task DeleteRole([FromBody] DeleteRole_Request request)
+        {
+            string roleName = request.roleName;
+
             //Check that the role name is not null or empty.
             if (roleName == null || roleName == "")
             {
@@ -170,9 +201,18 @@ namespace AbetApi.EFModels
             }
         } // DeleteRole
 
-        // This function removes a role from a user, selected via EUID
-        public async static Task RemoveRoleFromUser(string EUID, string roleName)
+
+        public class RemoveRoleFromUser_Request
         {
+            public string EUID { get; set; }
+            public string roleName { get; set; }
+        }
+        // This function removes a role from a user, selected via EUID
+        public async static Task RemoveRoleFromUser([FromBody] RemoveRoleFromUser_Request request)
+        {
+            string EUID = request.EUID;
+            string roleName = request.roleName;
+
             //Boolean variable for determining if a user has the role specified.
             bool userHasRole = false;
 

--- a/AbetApi/EFModels/User.cs
+++ b/AbetApi/EFModels/User.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using AbetApi.Data;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Mvc;
 
 //! The EFModels namespace
 /*! 
@@ -172,8 +173,10 @@ namespace AbetApi.EFModels
          * \param EUID The users EUID
          * \param NewUserInfo A User object with the edit info
          */
-        public async static Task EditUser(string EUID, User NewUserInfo)
+        public async static Task EditUser([FromBody] AxiosRequest.EditUser request)
         {
+            string EUID = request.EUID;
+            User NewUserInfo = request.NewUserInfo;
             //Sets the user ID to 0, to allow the database to auto increment the UserId value
             NewUserInfo.UserId = 0;
 

--- a/AbetApi/EFModels/User.cs
+++ b/AbetApi/EFModels/User.cs
@@ -171,10 +171,8 @@ namespace AbetApi.EFModels
          * \param EUID The users EUID
          * \param NewUserInfo A User object with the edit info
          */
-        public async static Task EditUser([FromBody] AxiosRequest.EditUser request)
+        public async static Task EditUser(string EUID, User NewUserInfo)
         {
-            string EUID = request.EUID;
-            User NewUserInfo = request.NewUserInfo;
             //Sets the user ID to 0, to allow the database to auto increment the UserId value
             NewUserInfo.UserId = 0;
 

--- a/AbetApi/EFModels/User.cs
+++ b/AbetApi/EFModels/User.cs
@@ -155,9 +155,7 @@ namespace AbetApi.EFModels
 
                 //If the specified user does not exist, then throw an exception.
                 if (user == null)
-                {
                     throw new ArgumentException("The user specified does not exist in the database.");
-                }
 
                 return user;
             }
@@ -182,27 +180,19 @@ namespace AbetApi.EFModels
 
             //Check that the EUID of the existing user information is not null or empty.
             if (EUID == null || EUID == "")
-            {
                 throw new ArgumentException("The EUID for the user to edit cannot be empty.");
-            }
 
             //Check that the first name of the new user information is not null or empty.
             if (NewUserInfo.FirstName == null || NewUserInfo.FirstName == "")
-            {
                 throw new ArgumentException("The new first name cannot be empty.");
-            }
 
             //Check that the last name of the new user information is not null or empty.
             if (NewUserInfo.LastName == null || NewUserInfo.LastName == "")
-            {
                 throw new ArgumentException("The new last name cannot be empty.");
-            }
 
             //Check that the EUID of the new user information is not null or empty.
             if (NewUserInfo.EUID == null || NewUserInfo.EUID == "")
-            {
                 throw new ArgumentException("The new EUID cannot be empty.");
-            }
 
             //Format first name, last name, and EUID of the new user information to follow a standard.
             NewUserInfo.FirstName = NewUserInfo.FirstName[0].ToString().ToUpper() + NewUserInfo.FirstName[1..].ToLower();
@@ -216,9 +206,7 @@ namespace AbetApi.EFModels
 
                 //Check to make sure the specified user to work on was a valid user from the database and throw an exception if it was not.
                 if(user == null)
-                {
                     throw new ArgumentException("The user you wanted to edit does not exist in the database.");
-                }
 
                 //If we are trying to change the EUID, then make sure that we aren't trying to duplicate an EUID.
                 if (EUID != NewUserInfo.EUID)
@@ -228,9 +216,7 @@ namespace AbetApi.EFModels
 
                     //If the new user already exists in the database, then that is a duplicate and we do not allow duplicates.
                     if (duplicateUser != null)
-                    {
                         throw new ArgumentException("The EUID to change to already exists in the database.");
-                    }
                 }
 
                 //Copy new values of user over to the user that's being edited
@@ -249,16 +235,15 @@ namespace AbetApi.EFModels
          * It then checks if the user exists, and if so, deletes them and saves the changes.
          * \param EUID A string with the users EUID
          */
-        public async static Task DeleteUser(string EUID)
+        public async static Task DeleteUser([FromBody] AxiosRequest.DeleteUser request)
         {
+
             //Check that the EUID of the user to delete is not null or empty.
-            if (EUID == null || EUID == "")
-            {
+            if (request.euid == null || request.euid == "")
                 throw new ArgumentException("The EUID cannot be empty.");
-            }
 
             //Format EUID to follow a standard.
-            EUID = EUID.ToLower();
+            string EUID = request.euid.ToLower();
 
             await using (var context = new ABETDBContext())
             {
@@ -270,6 +255,29 @@ namespace AbetApi.EFModels
                 {
                     throw new ArgumentException("The user you wanted to delete does not exist in the database.");
                 }
+
+                //Delete the result, and save changes
+                context.Remove(user);
+                context.SaveChanges();
+            }
+        } // DeleteUser
+        public async static Task DeleteUser(string EUID)
+        {
+            //Check that the EUID of the user to delete is not null or empty.
+            if (EUID == null || EUID == "")
+                throw new ArgumentException("The EUID cannot be empty.");
+
+            //Format EUID to follow a standard.
+            EUID = EUID.ToLower();
+
+            await using (var context = new ABETDBContext())
+            {
+                //find the user with a matching EUID
+                User user = context.Users.FirstOrDefault(p => p.EUID == EUID);
+
+                //Check to make sure the specified user to work on was a valid user from the database and throw an exception if it was not.
+                if (user == null)
+                    throw new ArgumentException("The user you wanted to delete does not exist in the database.");
 
                 //Delete the result, and save changes
                 context.Remove(user);
@@ -289,9 +297,7 @@ namespace AbetApi.EFModels
         {
             //Check that the EUID of the user to find is not null or empty.
             if (EUID == null || EUID == "")
-            {
                 throw new ArgumentException("The EUID cannot be empty.");
-            }
 
             //Format EUID to follow a standard.
             EUID = EUID.ToLower();
@@ -303,9 +309,7 @@ namespace AbetApi.EFModels
 
                 //Throw an exception if the user specified does not exist.
                 if (user == null)
-                {
                     return null;
-                }
 
                 //This uses explicit loading to tell the database we want Roles loaded
                 context.Entry(user).Collection(user => user.Roles).Load();


### PR DESCRIPTION
_security-patch_ fixes the problem where API calls were passing sensitive data, such as EUIDs and passwords, to the backend using query params in the URL, which were visible in plaintext. This patch modifies the backend endpoints to parse the parameters from the request body instead of from the URL query params.

To accomplish this, the [`[FromBody]` attribute](https://learn.microsoft.com/en-us/aspnet/web-api/overview/formats-and-model-binding/parameter-binding-in-aspnet-web-api#using-frombody) was added to the parameter of the request. That forces the Web API to read a simple type from the request body.
Since the parameters are no longer the individual query params from the URL as strings and ints, the function needed to know the expected shape of the object it was receiving. For testing, we made a temporary class that represented the shape of the request body, but this proved to make the file more messy. Instead, we created a new class `AxiosRequest` with subclasses created for each different request that use the `[FromBody] AxiosRequest` method to handle the API call.

Some functions were used both internally and externally (via the API), so for those we made a copy of the original before making a second one using the request body format. That way the internal function calls remained functional, and the API could call the new version with the matching format.